### PR TITLE
Systems JSON template; better naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,38 +45,56 @@ test-opensuse: &test-opensuse
 jobs:
   trusty:
     <<: *test-ubuntu
+    environment:
+      VER: 14.04
     docker:
       - image: ubuntu:trusty
   xenial:
     <<: *test-ubuntu
+    environment:
+      VER: 16.04
     docker:
       - image: ubuntu:xenial
   bionic:
     <<: *test-ubuntu
+    environment:
+      VER: 18.04
     docker:
       - image: ubuntu:bionic
   jessie:
     <<: *test-debian
+    environment:
+      VER: 8
     docker:
       - image: debian:jessie
   stretch:
     <<: *test-debian
+    environment:
+      VER: 9
     docker:
       - image: debian:stretch
   centos6:
     <<: *test-centos
+    environment:
+      VER: 6
     docker:
       - image: centos:6
   centos7:
     <<: *test-centos
+    environment:
+      VER: 7
     docker:
       - image: centos:7
   opensuse42:
     <<: *test-opensuse
+    environment:
+      VER: 42.3
     docker:
       - image: opensuse/leap:42.3
   opensuse15:
     <<: *test-opensuse
+    environment:
+      VER: 15.0
     docker:
       - image: opensuse/leap:15.0
 workflows:

--- a/generate-schema.js
+++ b/generate-schema.js
@@ -1,28 +1,15 @@
 let fs = require('fs')
 
 // The template for each distribution. Typically, you should not need to modify this.
-const system_template = function(os, name, distros) {
+const system_template = function(os, distribution) {
     return {
         "properties": {
-            "os": {"const": os},
-            "distribution": {
-                "enum": distros,
-            },
-            "version": {
+            "os": { "const": os },
+            "distribution": { "const": distribution },
+            "versions": {
                 "type": "array",
                 "items": {
-                    "type": "object",
-                    "minLength": 1,
-                    "properties": {
-                        "operator": {
-                            "enum": [ "==", "<", ">", "<=", ">=", "!=" ]
-                        },
-                        "value": {
-                            "$ref": `#/definitions/versions/${name}`
-                        },
-                    },
-                    "required": [ "value" ],
-                    "additionalProperties": false
+                    "$ref": `#/definitions/versions/${distribution}`
                 },
             }
         },
@@ -58,12 +45,12 @@ for (let i=0; i < systems.length; i++) {
     }
 
     // Each distribution needs a version definition...
-    defs.versions[system.name] = {
+    defs.versions[system.distribution] = {
         enum: versionsEnum
     }
 
     // ...and also a definition named after the distribution.
-    defs[system.name] = system_template('linux', system.name, system.distros)
+    defs[system.distribution] = system_template('linux', system.distribution)
 }
 
 // Insert the definitions in the schema and write it to disk.

--- a/rules/openmpi.json
+++ b/rules/openmpi.json
@@ -19,7 +19,28 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "redhat",
+          "versions": [ "7" ]
+        },
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": [ "7" ]
+        }
+      ]
+    },
+    {
+      "packages": ["openmpi-1.10-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": [ "6" ]
+        },
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": [ "6" ]
         }
       ]
     },

--- a/schema.json
+++ b/schema.json
@@ -91,6 +91,9 @@
                   "$ref": "#/definitions/centos"
                 },
                 {
+                  "$ref": "#/definitions/redhat"
+                },
+                {
                   "$ref": "#/definitions/opensuse"
                 },
                 {
@@ -116,14 +119,14 @@
     "versions": {
       "debian": {
         "enum": [
-          "stretch",
-          "buster"
+          "8",
+          "9"
         ]
       },
       "ubuntu": {
         "enum": [
-          "xenial",
-          "bionic"
+          "16.04",
+          "18.04"
         ]
       },
       "centos": {
@@ -132,16 +135,22 @@
           "7"
         ]
       },
+      "redhat": {
+        "enum": [
+          "6",
+          "7"
+        ]
+      },
       "opensuse": {
         "enum": [
-          "42",
-          "15"
+          "42.3",
+          "15.0"
         ]
       },
       "sle": {
         "enum": [
-          "12",
-          "15"
+          "12.3",
+          "15.0"
         ]
       }
     },
@@ -151,34 +160,12 @@
           "const": "linux"
         },
         "distribution": {
-          "enum": [
-            "debian"
-          ]
+          "const": "debian"
         },
-        "version": {
+        "versions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "minLength": 1,
-            "properties": {
-              "operator": {
-                "enum": [
-                  "==",
-                  "<",
-                  ">",
-                  "<=",
-                  ">=",
-                  "!="
-                ]
-              },
-              "value": {
-                "$ref": "#/definitions/versions/debian"
-              }
-            },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
+            "$ref": "#/definitions/versions/debian"
           }
         }
       },
@@ -193,34 +180,12 @@
           "const": "linux"
         },
         "distribution": {
-          "enum": [
-            "ubuntu"
-          ]
+          "const": "ubuntu"
         },
-        "version": {
+        "versions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "minLength": 1,
-            "properties": {
-              "operator": {
-                "enum": [
-                  "==",
-                  "<",
-                  ">",
-                  "<=",
-                  ">=",
-                  "!="
-                ]
-              },
-              "value": {
-                "$ref": "#/definitions/versions/ubuntu"
-              }
-            },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
+            "$ref": "#/definitions/versions/ubuntu"
           }
         }
       },
@@ -235,35 +200,32 @@
           "const": "linux"
         },
         "distribution": {
-          "enum": [
-            "centos",
-            "redhat"
-          ]
+          "const": "centos"
         },
-        "version": {
+        "versions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "minLength": 1,
-            "properties": {
-              "operator": {
-                "enum": [
-                  "==",
-                  "<",
-                  ">",
-                  "<=",
-                  ">=",
-                  "!="
-                ]
-              },
-              "value": {
-                "$ref": "#/definitions/versions/centos"
-              }
-            },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
+            "$ref": "#/definitions/versions/centos"
+          }
+        }
+      },
+      "required": [
+        "os"
+      ],
+      "additionalProperties": false
+    },
+    "redhat": {
+      "properties": {
+        "os": {
+          "const": "linux"
+        },
+        "distribution": {
+          "const": "redhat"
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/versions/redhat"
           }
         }
       },
@@ -278,34 +240,12 @@
           "const": "linux"
         },
         "distribution": {
-          "enum": [
-            "opensuse"
-          ]
+          "const": "opensuse"
         },
-        "version": {
+        "versions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "minLength": 1,
-            "properties": {
-              "operator": {
-                "enum": [
-                  "==",
-                  "<",
-                  ">",
-                  "<=",
-                  ">=",
-                  "!="
-                ]
-              },
-              "value": {
-                "$ref": "#/definitions/versions/opensuse"
-              }
-            },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
+            "$ref": "#/definitions/versions/opensuse"
           }
         }
       },
@@ -320,34 +260,12 @@
           "const": "linux"
         },
         "distribution": {
-          "enum": [
-            "sle"
-          ]
+          "const": "sle"
         },
-        "version": {
+        "versions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "minLength": 1,
-            "properties": {
-              "operator": {
-                "enum": [
-                  "==",
-                  "<",
-                  ">",
-                  "<=",
-                  ">=",
-                  "!="
-                ]
-              },
-              "value": {
-                "$ref": "#/definitions/versions/sle"
-              }
-            },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
+            "$ref": "#/definitions/versions/sle"
           }
         }
       },

--- a/schema.template.json
+++ b/schema.template.json
@@ -91,6 +91,9 @@
                   "$ref": "#/definitions/centos"
                 },
                 {
+                  "$ref": "#/definitions/redhat"
+                },
+                {
                   "$ref": "#/definitions/opensuse"
                 },
                 {

--- a/systems.json
+++ b/systems.json
@@ -1,27 +1,26 @@
 [
     {
-        "name": "debian",
-        "distros": [ "debian" ],
-        "versions": [ "stretch", "buster" ]
+        "distribution": "debian",
+        "versions": [ "8", "9" ]
     },
     {
-        "name": "ubuntu",
-        "distros": [ "ubuntu" ],
-        "versions": [ "xenial", "bionic" ]
+        "distribution": "ubuntu",
+        "versions": [ "16.04", "18.04" ]
     },
     {
-        "name": "centos",
-        "distros": [ "centos", "redhat" ],
+        "distribution": "centos",
         "versions": [ "6", "7" ]
     },
     {
-        "name": "opensuse",
-        "distros": [ "opensuse" ],
-        "versions": [ "42", "15" ]
+        "distribution": "redhat",
+        "versions": [ "6", "7" ]
     },
     {
-        "name": "sle",
-        "distros": [ "sle" ],
-        "versions": [ "12", "15" ]
+        "distribution": "opensuse",
+        "versions": [ "42.3", "15.0" ]
+    },
+    {
+        "distribution": "sle",
+        "versions": [ "12.3", "15.0" ]
     }
 ]


### PR DESCRIPTION
* Adds `systems.json` as a better place to record systems information. We can add systems, distros, and versions to the JSON file now instead of needing to update `generate-schema.js`.
* Uses better naming conventions in `generate-schema.js`. 