### PR TITLE
Fix duplicate dependencies in system package tests

### DIFF
--- a/test/test-packages.sh
+++ b/test/test-packages.sh
@@ -82,7 +82,7 @@ find_dependencies() {
     rule=$1
     dist=$2
     version=$3
-    deps=$(jq < "$rule" | jq ".dependencies | map(select(.constraints[] | .distribution == \"$dist\")) | map(select(.constraints[] | .versions | . == null or contains([\"$version\"])))")
+    deps=$(jq < "$rule" | jq ".dependencies | map(select(.constraints[] | .distribution == \"$dist\" and (.versions | . == null or contains([\"$version\"]))))")
     echo $deps
 }
 


### PR DESCRIPTION
The tests are checking most of the system packages twice: https://circleci.com/gh/rstudio/r-system-requirements/512

There was something weird going on with the chained maps in jq. Combining the two select expressions seems to have fixed that. For comparison, see https://circleci.com/gh/rstudio/r-system-requirements/523