### PR TITLE
Install OpenSSL along with libssh2 on SUSE

### DIFF
--- a/rules/libssh2.json
+++ b/rules/libssh2.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "packages": ["libssh2-devel"],
+      "packages": ["libopenssl-devel", "libssh2-devel"],
       "constraints": [
         {
           "os": "linux",


### PR DESCRIPTION
Fixes git2r build failures by forcing libssh2's libssl dependency to be libopenssl-devel instead of libressl-devel.

We could still replace the OpenSSL rule with LibreSSL in the future, but I thought this was a less risky workaround for now. openSUSE already comes with libopenssl (runtime lib) installed, and SLES doesn't have LibreSSL by default.

Testing note: I've built git2r on opensuse 42 and 15 with this change to confirm that it works.