### PR TITLE
Add libicu

### DIFF
--- a/rules/libicu.json
+++ b/rules/libicu.json
@@ -1,0 +1,55 @@
+{
+  "patterns": ["\\bicu4c\\b"],
+  "dependencies": [
+    {
+      "packages": ["libicu-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["libicu-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["7"]
+        }
+      ]
+    },
+    {
+      "packages": ["libicu"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["6"]
+        }
+      ]
+    },
+    {
+      "packages": ["libicu-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add ICU for the stringi package: https://cran.r-project.org/web/packages/stringi/index.html

libicu is already a runtime dependency of R, but the stringi package needs the development files to use the system ICU rather than the bundled ICU (which causes issues for offline environments).

RHEL 6 doesn't have `libicu-devel` in its default repos (related: https://github.com/rstudio/r-builds/pull/33), so I just left as `libicu` for now.