### PR TITLE
Always add apt repo noninteractively

### DIFF
--- a/rules/gdal.json
+++ b/rules/gdal.json
@@ -11,7 +11,7 @@
       ],
       "pre_install": [
         { "command": "apt-get install -y software-properties-common" },
-        { "command": "add-apt-repository ppa:ubuntugis/ppa" },
+        { "command": "add-apt-repository -y ppa:ubuntugis/ppa" },
         { "command": "apt-get update" }
       ],
       "constraints": [


### PR DESCRIPTION
Minor tweak to https://github.com/rstudio/r-system-requirements/pull/27: run `add-apt-repository` with the `-y` flag for non-interactive use. We didn't see a prompt in CI/tests because it auto-accepts when running Docker without `-t`, but it does prompt if you're copy-pasting commands into a terminal.