### PR TITLE
Link opensuse libpng16-config to libpng-config.

### DIFF
--- a/rules/libpng.json
+++ b/rules/libpng.json
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "packages": ["libpng16-devel"],
+      "packages": ["libpng16-compat-devel"],
       "constraints": [
         {
           "os": "linux",
@@ -37,11 +37,6 @@
         {
           "os": "linux",
           "distribution": "sle"
-        }
-      ],
-      "post_install": [
-        {
-          "command": "ln -s /usr/bin/libpng16-config /usr/bin/libpng-config"
         }
       ]
     }

--- a/rules/libpng.json
+++ b/rules/libpng.json
@@ -38,6 +38,11 @@
           "os": "linux",
           "distribution": "sle"
         }
+      ],
+      "post_install": [
+        {
+          "command": "ln -s /usr/bin/libpng16-config /usr/bin/libpng-config"
+        }
       ]
     }
   ]


### PR DESCRIPTION
opensuse renamed libpng-devel to libpng16-devel, but R still depends on the `libpng-config` binary to be available. 