### PR TITLE
Install GEOS from UbuntuGIS on Ubuntu 16

### DIFF
--- a/rules/geos.json
+++ b/rules/geos.json
@@ -3,10 +3,26 @@
   "dependencies": [
     {
       "packages": ["libgeos-dev"],
+      "pre_install": [
+        { "command": "apt-get install -y software-properties-common" },
+        { "command": "add-apt-repository -y ppa:ubuntugis/ppa" },
+        { "command": "apt-get update" }
+      ],
       "constraints": [
         {
           "os": "linux",
-          "distribution": "ubuntu"
+          "distribution": "ubuntu",
+          "versions": ["14.04", "16.04"]
+        }
+      ]
+    },
+    {
+      "packages": ["libgeos-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["18.04"]
         },
         {
           "os": "linux",


### PR DESCRIPTION
Addresses the issue raised by @jspiewak here: https://github.com/rstudio/r-system-requirements/pull/27#discussion_r329198571

This should match the GDAL rule:
https://github.com/rstudio/r-system-requirements/blob/400aa6251e381c6d0674afff93171f710b9adf35/rules/gdal.json#L7-L35