### PR TITLE
Use dnf for all CentOS 8 commands

### DIFF
--- a/rules/geos.json
+++ b/rules/geos.json
@@ -85,7 +85,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["geos-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/haveged.json
+++ b/rules/haveged.json
@@ -24,7 +24,23 @@
         "constraints": [
           {
             "os": "linux",
-            "distribution": "centos"
+            "distribution": "centos",
+            "versions": ["6", "7"]
+          }
+        ]
+      },
+      {
+        "packages": ["haveged-devel"],
+        "pre_install": [
+          {
+            "command": "dnf install -y epel-release"
+          }
+        ],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "centos",
+            "versions": ["8"]
           }
         ]
       },

--- a/rules/hdf5.json
+++ b/rules/hdf5.json
@@ -24,7 +24,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["hdf5-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/hiredis.json
+++ b/rules/hiredis.json
@@ -25,7 +25,22 @@
         {
           "os": "linux",
           "distribution": "centos",
-          "versions": ["7", "8"]
+          "versions": ["7"]
+        }
+      ]
+    },
+    {
+      "packages": ["hiredis-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/libbsd.json
+++ b/rules/libbsd.json
@@ -24,7 +24,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["libbsd-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/libsodium.json
+++ b/rules/libsodium.json
@@ -25,7 +25,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["libsodium-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/netcdf4.json
+++ b/rules/netcdf4.json
@@ -24,7 +24,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["netcdf-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/proj.json
+++ b/rules/proj.json
@@ -24,7 +24,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["proj-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/rust.json
+++ b/rules/rust.json
@@ -25,7 +25,22 @@
         {
           "os": "linux",
           "distribution": "centos",
-          "versions": ["7", "8"]
+          "versions": ["7"]
+        }
+      ]
+    },
+    {
+      "packages": ["rust", "cargo"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/tesseract.json
+++ b/rules/tesseract.json
@@ -24,7 +24,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["tesseract-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },

--- a/rules/udunits2.json
+++ b/rules/udunits2.json
@@ -69,7 +69,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["udunits2-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     }

--- a/rules/zeromq.json
+++ b/rules/zeromq.json
@@ -24,7 +24,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["zeromq-devel"],
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
         }
       ]
     },


### PR DESCRIPTION
@ssin2017 found that there were a couple `yum install -y epel-release` commands showing for CentOS 8. While `yum` still works on CentOS 8 (and is aliased to `dnf`), it's deprecated and looks odd when mixed into a list of `dnf` commands. This splits the CentOS-generic EPEL rules into a `yum` version and a `dnf` version.