### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,11 @@
+---
+name: Bug report
+about: Report a bug in an existing system requirements rule
+---
+
+<!--
+Thanks for taking the time to file a bug report!
+
+Please include any information about the operating systems
+or R packages for which the issue was observed, if relevant.
+-->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,11 @@
+---
+name: Feature request
+about: Request a new feature or system requirements rule
+---
+
+<!--
+Thanks for taking the time to file a feature request!
+
+If requesting a new system requirements rule, please include examples of
+R packages and SystemRequirements fields for which the rule would apply.
+-->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Ask a question
+about: Ask a question
+---
+
+<!--
+NOTE: RStudio does not offer support for these rules. However, you may still ask
+questions here or at RStudio Community: https://community.rstudio.com
+-->


### PR DESCRIPTION
Add issue templates to report a bug, request a new rule, and ask a question. I've kept it to light guidance for now, since we haven't had many issues. We could add more structure later if needed.

Also, I might reword some of this later, still thinking... sometimes it's hard to tell if a missing system dependency is a bug in an existing rule or just a missing rule. We might need a more general, catch-all "report missing sys dep" template.