### PR TITLE
Remove libssh2 on CentOS 8

### DIFF
--- a/rules/libssh2.json
+++ b/rules/libssh2.json
@@ -29,16 +29,6 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos",
-          "versions": ["8"]
-        }
-      ]
-    },
-    {
-      "packages": ["libssh2"],
-      "constraints": [
-        {
-          "os": "linux",
           "distribution": "redhat"
         }
       ]


### PR DESCRIPTION
`libssh2` appears to missing from CentOS 8: https://circleci.com/gh/rstudio/r-system-requirements/1361

But it was definitely available before: https://circleci.com/gh/rstudio/r-system-requirements/1335
```
libssh2 | Available Packages libssh2.x86_64 1.8.0-8.module_el8.0.0+189+f9babebb.1 AppStream
```

It's definitely there in the AppStream repo for CentOS 8.0.1905:
- http://vault.centos.org/8.0.1905/AppStream/Source/SPackages/
- http://vault.centos.org/8.0.1905/AppStream/Source/SPackages/libssh2-1.8.0-8.module_el8.0.0+189+f9babebb.1.src.rpm

But not in the latest point release, CentOS 8.1.1911: http://mirror.centos.org/centos/8/AppStream/x86_64/os/Packages/

No idea if it's a bug or if it was intentionally removed. Maybe related is this bug report of `libssh2-devel` being missing for a while now: https://bugs.centos.org/view.php?id=16492

This removes libssh2 on CentOS 8 to get builds working again. I think there's only one package on CRAN that uses libssh2, git2r. And git2r lists libssh2 as an optional dependency (and builds without it), so this shouldn't be too bad for now.

I didn't remove it for RHEL 8 because it seems to still be there, at least in Amazon's RHEL repos:
```sh
$ sudo dnf info libssh2
Last metadata expiration check: 0:01:47 ago on Tue 25 Feb 2020 11:53:47 PM UTC.
Available Packages
Name         : libssh2
Version      : 1.8.0
Release      : 8.module+el8.0.0+4084+cceb9f44.1
Architecture : x86_64
Size         : 99 k
Source       : libssh2-1.8.0-8.module+el8.0.0+4084+cceb9f44.1.src.rpm
Repository   : rhel-8-appstream-rhui-rpms
Summary      : A library implementing the SSH2 protocol
URL          : http://www.libssh2.org/
License      : BSD
Description  : libssh2 is a library implementing the SSH2 protocol as defined by
             : Internet Drafts: SECSH-TRANS(22), SECSH-USERAUTH(25),
             : SECSH-CONNECTION(23), SECSH-ARCH(20), SECSH-FILEXFER(06)*,
             : SECSH-DHGEX(04), and SECSH-NUMBERS(10).
```
