### PR TITLE
Run distro tests on a nightly basis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,3 +117,22 @@ workflows:
       - centos8
       - opensuse42
       - opensuse15
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - trusty
+      - xenial
+      - bionic
+      - jessie
+      - stretch
+      - centos6
+      - centos7
+      - centos8
+      - opensuse42
+      - opensuse15


### PR DESCRIPTION
Run the system package tests every night to help catch issues like https://github.com/rstudio/r-system-requirements/pull/44 earlier.

If this fails, I think it'll just email everyone who follows the r-system-requirements project on CircleCI. If you want to be notified, you can follow the project here: https://circleci.com/gh/rstudio/r-system-requirements/edit

https://circleci.com/docs/2.0/workflows/#nightly-example

