### PR TITLE
Re-add Windows system requirements

### DIFF
--- a/rules/cairo.json
+++ b/rules/cairo.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-cairo",
+        "mingw-w64-i686-cairo"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/coin-or-clp.json
+++ b/rules/coin-or-clp.json
@@ -13,6 +13,17 @@
           "distribution": "debian"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-coinor-cbc",
+        "mingw-w64-i686-coinor-cbc"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/fftw3.json
+++ b/rules/fftw3.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-fftw",
+        "mingw-w64-i686-fftw"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/freetype.json
+++ b/rules/freetype.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-freetype",
+        "mingw-w64-i686-freetype"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/geos.json
+++ b/rules/geos.json
@@ -113,6 +113,17 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-geos",
+        "mingw-w64-i686-geos"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/glpk.json
+++ b/rules/glpk.json
@@ -60,6 +60,17 @@
           "versions": ["8"]
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-glpk",
+        "mingw-w64-i686-glpk"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/gmp.json
+++ b/rules/gmp.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-gmp",
+        "mingw-w64-i686-gmp"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/gsl.json
+++ b/rules/gsl.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-gsl",
+        "mingw-w64-i686-gsl"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/hdf5.json
+++ b/rules/hdf5.json
@@ -102,6 +102,17 @@
           "versions": ["12.3"]
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-hdf5",
+        "mingw-w64-i686-hdf5"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/leptonica.json
+++ b/rules/leptonica.json
@@ -81,6 +81,17 @@
           "distribution": "opensuse"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-leptonica",
+        "mingw-w64-i686-leptonica"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libarchive.json
+++ b/rules/libarchive.json
@@ -75,6 +75,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libarchive",
+        "mingw-w64-i686-libarchive"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libcurl.json
+++ b/rules/libcurl.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-curl",
+        "mingw-w64-i686-curl"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libicu.json
+++ b/rules/libicu.json
@@ -50,6 +50,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-icu",
+        "mingw-w64-i686-icu"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libjpeg.json
+++ b/rules/libjpeg.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libjpeg",
+        "mingw-w64-i686-libjpeg"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libpng.json
+++ b/rules/libpng.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libpng",
+        "mingw-w64-i686-libpng"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libprotobuf.json
+++ b/rules/libprotobuf.json
@@ -76,6 +76,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-protobuf",
+        "mingw-w64-i686-protobuf"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libssh2.json
+++ b/rules/libssh2.json
@@ -45,6 +45,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libssh2",
+        "mingw-w64-i686-libssh2"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libtiff.json
+++ b/rules/libtiff.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libtiff",
+        "mingw-w64-i686-libtiff"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/libxml2.json
+++ b/rules/libxml2.json
@@ -39,6 +39,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libxml2",
+        "mingw-w64-i686-libxml2"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/nlopt.json
+++ b/rules/nlopt.json
@@ -1,0 +1,16 @@
+{
+  "patterns": ["\\bnlopt\\b"],
+  "dependencies": [
+    {
+      "packages": [
+        "mingw-w64-x86_64-nlopt",
+        "mingw-w64-i686-nlopt"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
+    }
+  ]
+}

--- a/rules/openssl.json
+++ b/rules/openssl.json
@@ -39,6 +39,17 @@
             "distribution": "sle"
           }
         ]
-      }
+      },
+    {
+      "packages": [
+        "mingw-w64-x86_64-openssl",
+        "mingw-w64-i686-openssl"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
+    }
     ]
   }

--- a/rules/postgresql.json
+++ b/rules/postgresql.json
@@ -61,6 +61,17 @@
           "distribution": "sle"
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libpq",
+        "mingw-w64-i686-libpq"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/python3.json
+++ b/rules/python3.json
@@ -86,6 +86,17 @@
             "distribution": "sle"
           }
         ]
-      }
+      },
+    {
+      "packages": [
+        "mingw-w64-x86_64-python3",
+        "mingw-w64-i686-python3"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
+    }
     ]
   }

--- a/rules/redland.json
+++ b/rules/redland.json
@@ -60,6 +60,17 @@
           "versions": ["12.3"]
         }
       ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-redland",
+        "mingw-w64-i686-redland"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
     }
   ]
 }

--- a/rules/zlib.json
+++ b/rules/zlib.json
@@ -39,6 +39,17 @@
             "distribution": "sle"
           }
         ]
+      },
+      {
+        "packages": [
+          "mingw-w64-x86_64-zlib",
+          "mingw-w64-i686-zlib"
+        ],
+        "constraints": [
+          {
+            "os": "windows"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
- Reverts https://github.com/rstudio/r-system-requirements/pull/42 for R 4.0 support
- Adds a rule for NLopt on Windows, specifically for the nloptr package