### PR TITLE
Fix FreeType rule to recognize "freetype2"

### DIFF
--- a/rules/freetype.json
+++ b/rules/freetype.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\bfreetype\\b"],
+  "patterns": ["\\bfreetype\\b", "\\bfreetype2\\b"],
   "dependencies": [
     {
       "packages": ["libfreetype6-dev"],


### PR DESCRIPTION
For packages like ragg, which use "freetype2" in their system requirements. FreeType and FreeType 2 are usually synonymous, so package authors will write it either way.

For ragg's systemfonts dependency, @colearendt is conveniently already adding a fontconfig rule here: https://github.com/rstudio/r-system-requirements/pull/48/commits/3f7771e7182bc27bf80ad3569647d7a9337fd340

Once these two PRs are merged, we should have ragg and systemfonts binaries after they get updated on CRAN.