### PR TITLE
Fix ImageMagick on CentOS/RHEL 8

### DIFF
--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -19,7 +19,23 @@
         "constraints": [
           {
             "os": "linux",
-            "distribution": "centos"
+            "distribution": "centos",
+            "versions": ["6", "7"]
+          }
+        ]
+      },
+      {
+        "packages": ["ImageMagick", "ImageMagick-c++-devel"],
+        "pre_install": [
+          { "command": "dnf install -y dnf-plugins-core" },
+          { "command": "dnf config-manager --set-enabled PowerTools" },
+          { "command": "dnf install -y epel-release" }
+        ],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "centos",
+            "versions": ["8"]
           }
         ]
       },
@@ -28,7 +44,23 @@
         "constraints": [
           {
             "os": "linux",
-            "distribution": "redhat"
+            "distribution": "redhat",
+            "versions": ["6", "7"]
+          }
+        ]
+      },
+      {
+        "packages": ["ImageMagick", "ImageMagick-c++"],
+        "pre_install": [
+          {
+            "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+          }
+        ],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "redhat",
+            "versions": ["8"]
           }
         ]
       },


### PR DESCRIPTION
ImageMagick was moved to EPEL with CentOS/RHEL 8. You also need the PowerTools repo to install the `-devel` package on CentOS 8.

I left out the `-devel` package on RHEL 8 because I don't know where to get it. It might be in the `codeready-builder-for-rhel-8-x86_64-rpms` (or the AWS equivalent `codeready-builder-for-rhel-8-rhui-rpms`)  repo, but I haven't been able to get that repo working in the AWS AMIs yet.