### PR TITLE
Add GDAL for CentOS/RHEL 8

### DIFF
--- a/rules/gdal.json
+++ b/rules/gdal.json
@@ -94,6 +94,43 @@
       ]
     },
     {
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled PowerTools" },
+        { "command": "dnf install -y epel-release" }
+      ],
+      "packages": [
+        "gdal-devel",
+        "gdal",
+        "sqlite-devel"
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms" },
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm" }
+      ],
+      "packages": [
+        "gdal-devel",
+        "gdal",
+        "sqlite-devel"
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
       "packages": [
         "gdal-devel",
         "gdal"


### PR DESCRIPTION
GDAL was recently added to EPEL 8. The devel package also requires the PowerTools repo on CentOS 8, and the CodeReady Linux Builder repo on RHEL 8.

I've also added sqlite here, which is an optional dependency for GDAL, but not included in the gdal-devel package. sf needs sqlite to build, but doesn't declare it in SystemRequirements.

At least on Ubuntu/Debian, the GDAL dev package directly depends on sqlite:

```sh
$ apt-cache depends libgdal-dev | grep sqlite
  Depends: libsqlite3-dev
```

So I think this is ok to include for now.