### PR TITLE
Add libgit2

### DIFF
--- a/rules/libgit2.json
+++ b/rules/libgit2.json
@@ -1,0 +1,113 @@
+{
+  "patterns": ["\\blibgit2\\b"],
+  "dependencies": [
+    {
+      "packages": ["libgit2-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["20.04"]
+        }
+      ]
+    },
+    {
+      "packages": ["libgit2-devel"],
+      "pre_install": [
+        {
+          "command": "yum install -y epel-release"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["6"]
+        }
+      ]
+    },
+    {
+      "packages": ["libgit2-devel"],
+      "pre_install": [
+        {
+          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["6"]
+        }
+      ]
+    },
+    {
+      "packages": ["libgit2-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["7"]
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["7"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled PowerTools" }
+      ],
+      "packages": ["libgit2-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        {
+          "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms"
+        }
+      ],
+      "packages": ["libgit2-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "packages": ["libgit2-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle",
+          "versions": ["15.0"]
+        }
+      ]
+    },
+    {
+      "packages": ["libgit2-24"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "sle",
+          "versions": ["12.3"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds libgit2 for the gert package. This excludes Ubuntu 16/18 and Debian 9 because libgit2-dev conflicts with libcurl4-openssl-dev:
```sh
$ apt-get install -y libcurl4-openssl-dev libgit2-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libcurl4-openssl-dev is already the newest version (7.58.0-2ubuntu3.9).
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libgit2-dev : Depends: libcurl4-gnutls-dev but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```
It may be added later via the `cran/travis` PPA, which contains a non-conflicting version of libgit2-dev.

Other notes:

- CentOS/RHEL 6 require EPEL
- CentOS/RHEL 8 require PowerTools and CodeReady Builder
- SLES 12 only has the non-dev libgit2