### PR TITLE
Don't run nightly tests at midnight

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 2 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
The nightly tests keep failing randomly for reasons like:
```
chromium | Error: Failed to download metadata for repo 'epel': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```
```
QuantLib-devel | https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/6/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel
```

Probably not a great idea to run them at midnight UTC, so do it a bit later.