### PR TITLE
On SLES/openSUSE add a check for repo existence

### DIFF
--- a/rules/gdal.json
+++ b/rules/gdal.json
@@ -146,7 +146,7 @@
       "packages": ["gdal-devel", "gdal"],
       "pre_install": [
         {
-          "command": "zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/openSUSE:Backports:SLE-12.repo"
+          "command": "zypper repos openSUSE_Backports_SLE-12 || zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/openSUSE:Backports:SLE-12.repo"
         },
         {
           "command": "zypper --gpg-auto-import-keys refresh"

--- a/rules/proj.json
+++ b/rules/proj.json
@@ -102,7 +102,7 @@
       "packages": ["libproj-devel", "proj"],
       "pre_install": [
         {
-          "command": "zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/openSUSE:Backports:SLE-12.repo"
+          "command": "zypper repos openSUSE_Backports_SLE-12 || zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/openSUSE:Backports:SLE-12.repo"
         },
         {
           "command": "zypper --gpg-auto-import-keys refresh"


### PR DESCRIPTION
From Slack

> For pre-install commands on SLES/openSUSE, could we add a check for a repo's existence before adding? e.g. on SLES 12, instead of the following:

```
zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/openSUSE:Backports:SLE-12.repo
```

> Change to:

```
zypper repos openSUSE_Backports_SLE-12 || zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/openSUSE:Backports:SLE-12.repo
```

> The reason being is that zypper addrepo exits with return code != 0 if the repo already exists