### PR TITLE
Add proj-epsg for CentOS/RHEL 7

### DIFF
--- a/rules/proj.json
+++ b/rules/proj.json
@@ -15,7 +15,7 @@
       ]
     },
     {
-      "packages": ["proj-devel"],
+      "packages": ["proj-devel", "proj-epsg"],
       "pre_install": [
         {
           "command": "yum install -y epel-release"
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "packages": ["proj-devel"],
+      "packages": ["proj-devel", "proj-epsg"],
       "pre_install": [
         {
           "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
@@ -60,7 +60,7 @@
       ]
     },
     {
-      "packages": ["proj-devel"],
+      "packages": ["proj-devel", "proj-epsg"],
       "pre_install": [
         {
           "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"


### PR DESCRIPTION
rgdal now requires `proj-epsg` on CentOS/RHEL 7. I believe `proj-epsg` is an extra dataset for PROJ in CentOS/RHEL 6 and 7. In CentOS/RHEL 8, the extra data is now shipped with `proj`, so you automatically get it when installing `proj-devel`.