### PR TITLE
Harfbuzz and Fribidi support

### DIFF
--- a/rules/fribidi.json
+++ b/rules/fribidi.json
@@ -1,0 +1,31 @@
+{
+  "patterns": ["\\bfribidi\\b"],
+  "dependencies": [
+    {
+      "packages": ["libfribidi-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        }
+      ]
+    },
+    {
+      "packages": ["fribidi-deve"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat"
+        },
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        }
+      ]
+    }
+  ]
+}

--- a/rules/fribidi.json
+++ b/rules/fribidi.json
@@ -11,15 +11,17 @@
       ]
     },
     {
-      "packages": ["fribidi-deve"],
+      "packages": ["fribidi-devel"],
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["7", "8"]
         },
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "redhat",
+          "versions": ["7", "8"]
         },
         {
           "os": "linux",

--- a/rules/harfbuzz.json
+++ b/rules/harfbuzz.json
@@ -15,11 +15,13 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["7", "8"]
         },
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "redhat",
+          "versions": ["7", "8"]
         },
         {
           "os": "linux",

--- a/rules/harfbuzz.json
+++ b/rules/harfbuzz.json
@@ -1,0 +1,31 @@
+{
+  "patterns": ["\\bharfbuzz\\b"],
+  "dependencies": [
+    {
+      "packages": ["libharfbuzz-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        }
+      ]
+    },
+    {
+      "packages": ["harfbuzz-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat"
+        },
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a PR to fix #58 which adds support for the harfbuzz and fribidi libraries for text shaping. As for now there is only 1 package targeting these libraries: https://cran.r-project.org/web/packages/textshaping/index.html