### PR TITLE
libjq: Add missing EPEL pre-install for CentOS/RHEL 7, add Ubuntu 20

### DIFF
--- a/rules/libjq.json
+++ b/rules/libjq.json
@@ -4,6 +4,11 @@
   ],
   "dependencies": [
     {
+      "pre_install": [
+        {
+          "command": "yum install -y epel-release"
+        }
+      ],
       "packages": [
         "jq-devel"
       ],
@@ -12,7 +17,19 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["7"]
-        },
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        {
+          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+        }
+      ],
+      "packages": [
+        "jq-devel"
+      ],
+      "constraints": [
         {
           "os": "linux",
           "distribution": "redhat",
@@ -28,7 +45,7 @@
         {
           "os": "linux",
           "distribution": "ubuntu",
-          "versions": ["18.04"]
+          "versions": ["18.04", "20.04"]
         },
         {
           "os": "linux",


### PR DESCRIPTION
Fixes libjq on CentOS/RHEL 7, and adds Ubuntu 20 support. I also checked CentOS/RHEL 8, but it still doesn't have a jq-devel package yet.