### PR TITLE
Remove mongodb for CentOS/RHEL 7

### DIFF
--- a/rules/mongodb.json
+++ b/rules/mongodb.json
@@ -25,7 +25,7 @@
         {
           "os": "linux",
           "distribution": "centos",
-          "versions": ["6", "7"]
+          "versions": ["6"]
         }
       ]
     },
@@ -41,21 +41,6 @@
           "os": "linux",
           "distribution": "redhat",
           "versions": ["6"]
-        }
-      ]
-    },
-    {
-      "packages": ["mongodb"],
-      "pre_install": [
-        {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-        }
-      ],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "redhat",
-          "versions": ["7"]
         }
       ]
     },


### PR DESCRIPTION
The daily tests have been failing recently because the `mongodb` package was dropped from EPEL 7: https://repology.org/project/mongodb/history. I assume it's because of licensing reasons: https://fedoraproject.org/wiki/Changes/MongoDB_Removal

I don't think any R packages actually required the `mongodb` package though (https://github.com/rstudio/r-system-requirements/issues/53), so it should be fine to remove.