### PR TITLE
Add rule for blender on Ubuntu and SUSE

### DIFF
--- a/rules/blender.json
+++ b/rules/blender.json
@@ -1,0 +1,31 @@
+{
+    "patterns": ["\\bblender\\b"],
+    "dependencies": [
+      {
+        "packages": ["blender"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "ubuntu"
+          },
+          {
+            "os": "linux",
+            "distribution": "debian"
+          }
+        ]
+      },
+      {
+        "packages": ["blender"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "opensuse"
+          },
+          {
+            "os": "linux",
+            "distribution": "sle"
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds a rule for [Blender](https://www.blender.org/) on Ubuntu and SUSE OS. It does not include a rule for CentOS or RHEL, as Blender can't be installed via yum; there's a snap available, but I didn't see an obvious way to specify "use snap to install instead of yum" in the JSON.

At the moment, I do not believe this matches any packages (at least, `npm run test-patterns -- rules/blender.json` returns 0 matches), but I am currently working on a package this will help -- my main goal in merging this at the moment is to simplify my GitHub Actions check.yaml :) 