### PR TITLE
Update CentOS 8 rules for powertools repo rename

### DIFF
--- a/rules/gdal.json
+++ b/rules/gdal.json
@@ -96,7 +96,7 @@
     {
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" },
+        { "command": "dnf config-manager --set-enabled powertools" },
         { "command": "dnf install -y epel-release" }
       ],
       "packages": [

--- a/rules/gpgme.json
+++ b/rules/gpgme.json
@@ -28,7 +28,7 @@
         "packages": ["gpgme-devel"],
         "pre_install": [
           { "command": "dnf install -y dnf-plugins-core" },
-          { "command": "dnf config-manager --set-enabled PowerTools" }
+          { "command": "dnf config-manager --set-enabled powertools" }
         ],
         "constraints": [
           {

--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -28,7 +28,7 @@
         "packages": ["ImageMagick", "ImageMagick-c++-devel"],
         "pre_install": [
           { "command": "dnf install -y dnf-plugins-core" },
-          { "command": "dnf config-manager --set-enabled PowerTools" },
+          { "command": "dnf config-manager --set-enabled powertools" },
           { "command": "dnf install -y epel-release" }
         ],
         "constraints": [

--- a/rules/leptonica.json
+++ b/rules/leptonica.json
@@ -33,7 +33,7 @@
       "packages": ["leptonica-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {

--- a/rules/libarchive.json
+++ b/rules/libarchive.json
@@ -28,7 +28,7 @@
       "packages": ["libarchive-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {

--- a/rules/libgit2.json
+++ b/rules/libgit2.json
@@ -59,7 +59,7 @@
     {
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "packages": ["libgit2-devel"],
       "constraints": [

--- a/rules/libmagic.json
+++ b/rules/libmagic.json
@@ -33,7 +33,7 @@
       "packages": ["file-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {

--- a/rules/libsndfile.json
+++ b/rules/libsndfile.json
@@ -28,7 +28,7 @@
       "packages": ["libsndfile-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {

--- a/rules/opencl.json
+++ b/rules/opencl.json
@@ -33,7 +33,7 @@
       "packages": ["ocl-icd", "opencl-headers"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {

--- a/rules/pandoc.json
+++ b/rules/pandoc.json
@@ -33,7 +33,7 @@
         "packages": ["pandoc"],
         "pre_install": [
           { "command": "dnf install -y dnf-plugins-core" },
-          { "command": "dnf config-manager --set-enabled PowerTools" }
+          { "command": "dnf config-manager --set-enabled powertools" }
         ],
         "constraints": [
           {

--- a/rules/poppler.json
+++ b/rules/poppler.json
@@ -28,7 +28,7 @@
       "packages": ["poppler-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {

--- a/rules/protobuf-compiler.json
+++ b/rules/protobuf-compiler.json
@@ -43,7 +43,7 @@
       "packages": ["protobuf-compiler"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {

--- a/rules/redland.json
+++ b/rules/redland.json
@@ -28,7 +28,7 @@
       "packages": ["redland-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled PowerTools" }
+        { "command": "dnf config-manager --set-enabled powertools" }
       ],
       "constraints": [
         {


### PR DESCRIPTION
The `PowerTools` repo was renamed to `powertools` (lowercase): https://bugs.centos.org/view.php?id=17920