### PR TITLE
Use the libgit2 ppa for libgit2-dev on 16.04 and 18.04

### DIFF
--- a/rules/libgit2.json
+++ b/rules/libgit2.json
@@ -3,6 +3,21 @@
   "dependencies": [
     {
       "packages": ["libgit2-dev"],
+      "pre_install": [
+        { "command": "apt-get install -y software-properties-common" },
+        { "command": "add-apt-repository -y ppa:ppa:cran/libgit2" },
+        { "command": "apt-get update" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["16.04", "18.04"]
+        }
+      ]
+    },
+    {
+      "packages": ["libgit2-dev"],
       "constraints": [
         {
           "os": "linux",

--- a/rules/libgit2.json
+++ b/rules/libgit2.json
@@ -5,7 +5,7 @@
       "packages": ["libgit2-dev"],
       "pre_install": [
         { "command": "apt-get install -y software-properties-common" },
-        { "command": "add-apt-repository -y ppa:ppa:cran/libgit2" },
+        { "command": "add-apt-repository -y ppa:cran/libgit2" },
         { "command": "apt-get update" }
       ],
       "constraints": [


### PR DESCRIPTION
As of the usethis release 2.0 it now depends on the [gert](https://github.com/r-lib/gert) package, which needs libgit2. As noted in https://github.com/rstudio/r-system-requirements/pull/56 libgit2-dev conflicts with libcurl4-openssl-dev on ubuntu 16.04 and 18.04, however @jeroen provides a backport PPA that will fix this.

This PR enables use of this ppa with libgit2 on these versions of ubuntu.