### PR TITLE
Use the GLU devel package on SUSE

### DIFF
--- a/rules/glu.json
+++ b/rules/glu.json
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "packages": ["libGLU1"],
+      "packages": ["glu-devel"],
       "constraints": [
         {
           "os": "linux",


### PR DESCRIPTION
Use the devel version of the GLU package on SUSE. This should get builds working for packages like rgl, which fail from missing GLU headers:

```sh
* installing *source* package ‘rgl’ ...
** package ‘rgl’ successfully unpacked and MD5 sums checked
configure: error: missing required header GL/glu.h
ERROR: configuration failed for package ‘rgl’
```

To test this out on SUSE, you can install `glu-devel` and `libpng16-compat-devel`, and try to build rgl:
```sh
$ docker run -it --rm rstudio/r-base:4.0-opensuse15 bash

$ zypper -n install glu-devel libpng16-compat-devel

$ R -e 'install.packages("rgl", repos = "https://packagemanager.rstudio.com/cran/__linux__/opensuse15/latest")'

...

g++ -std=gnu++11 -shared -L/opt/R/4.0.3/lib/R/lib -L/usr/local/lib -o rgl.so ABCLineSet.o BBoxDeco.o Background.o ClipPlane.o Color.o Disposable.o Light.o LineSet.o LineStripSet.o Material.o NULLgui.o PlaneSet.o PointSet.o PrimitiveSet.o RenderContext.o Shape.o SphereMesh.o SphereSet.o SpriteSet.o String.o Surface.o TextSet.o Texture.o Viewpoint.o api.o assert.o callbacks.o device.o devicemanager.o fps.o ftgl.o geom.o gl2ps.o glErrors.o glgui.o gui.o init.o par3d.o pixmap.o platform.o pretty.o render.o rglmath.o rglview.o scene.o select.o subscene.o win32gui.o win32lib.o x11gui.o x11lib.o -lGLU -lGL -L/usr/lib64 -lpng16 -lX11 -L/opt/R/4.0.3/lib/R/lib -lR
installing to /opt/R/4.0.3/lib/R/library/00LOCK-rgl/00new/rgl/libs
** R
** demo
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
Warning: 'rgl.init' failed, running with 'rgl.useNULL = TRUE'.
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
Warning: 'rgl.init' failed, running with 'rgl.useNULL = TRUE'.
** testing if installed package keeps a record of temporary installation path
* DONE (rgl)

The downloaded source packages are in
	‘/tmp/RtmpGxaMHA/downloaded_packages’
Updating HTML index of packages in '.Library'
Making 'packages.html' ... done
```