### PR TITLE
Fix for magick package

### DIFF
--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -2,7 +2,7 @@
     "patterns": ["\\bimagemagick\\b", "\\bimage magick\\b"],
     "dependencies": [
       {
-        "packages": ["imagemagick", "libmagick++-dev"],
+        "packages": ["imagemagick", "libmagick++-dev", "gsfonts"],
         "constraints": [
           {
             "os": "linux",


### PR DESCRIPTION
The gsfonts package is called by imagemagick when rendering text on images. It is unclear to me why debian has made this an optional dependency instead of a hard one.

Fixes https://github.com/ropensci/magick/issues/322#issuecomment-860051607