### PR TITLE
Fix ImageMagick for openSUSE

### DIFF
--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -65,7 +65,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-devel"],
+        "packages": ["ImageMagick", "ImageMagick-devel", "libMagick++-devel"],
         "constraints": [
           {
             "os": "linux",


### PR DESCRIPTION
Closes https://github.com/rstudio/r-system-requirements/issues/19. The ImageMagick rule for openSUSE has always been missing the `libMagick++-devel` package. There used to be a bug in the magick package that prevented it from installing on openSUSE 42, but that's apparently now resolved (https://github.com/rstudio/r-system-requirements/issues/19).

To test this, try to install the magick package without `libMagick++-devel` on any openSUSE version, then try it after adding `libMagick++-devel`:
```sh
$ docker run -it --rm rstudio/r-base:4.1-opensuse152 bash

# Without libMagick++-devel
$ R -e 'install.packages("magick", repos = "https://packagemanager.rstudio.com/cran/__linux__/opensuse152/latest")'
* installing *source* package ‘magick’ ...
** package ‘magick’ successfully unpacked and MD5 sums checked
** using staged installation
Package Magick++ was not found in the pkg-config search path.
Perhaps you should add the directory containing `Magick++.pc'
to the PKG_CONFIG_PATH environment variable
No package 'Magick++' found
Using PKG_CFLAGS=
Using PKG_LIBS=-lMagick++-6.Q16
--------------------------- [ANTICONF] --------------------------------
Configuration failed to find the Magick++ library. Try installing:
 - deb: libmagick++-dev (Debian, Ubuntu)
 - rpm: ImageMagick-c++-devel (Fedora, CentOS, RHEL)
 - csw: imagemagick_dev (Solaris)
 - brew imagemagick@6 (MacOS)
For Ubuntu versions Trusty (14.04) and Xenial (16.04) use our PPA:
   sudo add-apt-repository -y ppa:cran/imagemagick
   sudo apt-get update
   sudo apt-get install -y libmagick++-dev
If Magick++ is already installed, check that 'pkg-config' is in your
PATH and PKG_CONFIG_PATH contains a Magick++.pc file. If pkg-config
is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
-------------------------- [ERROR MESSAGE] ---------------------------
<stdin>:1:10: fatal error: Magick++.h: No such file or directory
compilation terminated.
--------------------------------------------------------------------
```
```sh
# With libMagick++-devel
$ zypper -n install libMagick++-devel

$ R -e 'install.packages("magick", repos = "https://packagemanager.rstudio.com/cran/__linux__/opensuse152/latest")'

* installing *source* package ‘magick’ ...
** package ‘magick’ successfully unpacked and MD5 sums checked
** using staged installation
Found pkg-config cflags and libs!
Using PKG_CFLAGS=-fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/usr/include/ImageMagick-6 
Using PKG_LIBS=-lMagick++-6.Q16 -lMagickWand-6.Q16 -lMagickCore-6.Q16 
** libs
g++ -std=gnu++11 -I"/opt/R/4.0.5/lib/R/include" -DNDEBUG -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -fopenmp -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/usr/include/ImageMagick-6  -I'/opt/R/4.0.5/lib/R/library/Rcpp/include' -I/usr/local/include  -fvisibility=hidden -fpic  -g -O2  -c RcppExports.cpp -o RcppExports.o
...
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (magick)
```