### PR TITLE
Use `sh` safe commands

### DIFF
--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -7,7 +7,7 @@
       "pre_install": [
         { "command": "[ $(which google-chrome) ] || apt-get install -y gnupg wget" },
         { "command": "[ $(which google-chrome) ] || wget -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" },
-        { "command": "DEBIAN_FRONTEND='noninteractive'; [ $(which google-chrome) ] || apt-get install -y /tmp/google-chrome.deb" }
+        { "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb" }
       ],
       "packages": [],
       "post_install": [

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -5,9 +5,9 @@
   "dependencies": [
     {
       "pre_install": [
-        { "command": "apt-get install -y gnupg wget" },
-        { "command": "if [ -z $(which google-chrome) ]; then wget -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb; fi" },
-        { "command": "if [ -z $(which google-chrome) ]; then DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb; fi" }
+        { "command": "[ $(which google-chrome) ] || apt-get install -y gnupg wget" },
+        { "command": "[ $(which google-chrome) ] || wget -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" },
+        { "command": "DEBIAN_FRONTEND='noninteractive'; [ $(which google-chrome) ] || apt-get install -y /tmp/google-chrome.deb" }
       ],
       "packages": [],
       "post_install": [
@@ -24,8 +24,8 @@
     {
       "pre_install": [
         { "command": "yum install -y which" },
-        { "command": "if [ -z $(which google-chrome) ]; then wget -O - https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm > /tmp/google-chrome.rpm; fi" },
-        { "command": "if [ -z $(which google-chrome) ]; then yum install -y /tmp/google-chrome.rpm; fi" }
+        { "command": "[ $(which google-chrome) ] || wget -O /tmp/google-chrome.rpm https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm" },
+        { "command": "[ $(which google-chrome) ] || yum install -y /tmp/google-chrome.rpm" }
       ],
       "packages": [],
       "post_install": [


### PR DESCRIPTION
I tried to install `chromote`, and thought it'd work. It did not work with `pak`. 

`pak` uses `sh -c COMMAND` which did not like the `if`/`then`/`else`/`fi`.

Ex: https://github.com/rstudio/chromote/pull/58/checks?check_run_id=3089030517#step:7:13

```
ℹ Executing `sudo apt-get install -y gnupg wget`
ℹ Executing `sudo if [ -z $(which google-chrome) ]; then wget -O /tmp/google-chrome.deb dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb; fi`

Error: Error: <callr_remote_error: System command 'sh' failed, exit status: 2, stdout + stderr:
```

I've tested locally using `sh -c COMMAND` and could reprex the problem.  The updated commands below, should work better with `sh -c COMMAND`.

------------------------

Within `bash`... The example below is an inline environment variable with a shorthand if-statement...

```
sh -c 'BARRET=schloerke; [ $(which google-chrome) ] || echo "$BARRET" '
# schloerke
```

---------------------------

Additional change:
* No need to try to install `gnupg` and `wget` if no other installation will attempt to install.