### PR TITLE
Use curl instead of wget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2
 install-jq: &install-jq
   name: Install jq
   command: |
-    wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+    curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
     chmod +x /usr/local/bin/jq
 
 test-ubuntu: &test-ubuntu
   steps:
     - checkout
     - run: cat /etc/*-release
-    - run: apt-get update -qq && apt-get install -y apt-transport-https wget
+    - run: apt-get update -qq && apt-get install -y apt-transport-https
     - run:
         <<: *install-jq
     - run: DIST=ubuntu ./test/test-packages.sh
@@ -19,7 +19,6 @@ test-debian: &test-debian
   steps:
     - checkout
     - run: cat /etc/*-release
-    - run: apt-get update -qq && apt-get install -y wget
     - run:
         <<: *install-jq
     - run: DIST=debian ./test/test-packages.sh
@@ -28,7 +27,6 @@ test-centos: &test-centos
   steps:
     - checkout
     - run: cat /etc/*-release
-    - run: yum update -y -q && yum install -y wget
     - run:
         <<: *install-jq
     - run: DIST=centos ./test/test-packages.sh
@@ -37,7 +35,6 @@ test-opensuse: &test-opensuse
   steps:
     - checkout
     - run: cat /etc/*-release
-    - run: zypper --quiet --non-interactive update && zypper --non-interactive install wget
     - run:
         <<: *install-jq
     - run: DIST=opensuse ./test/test-packages.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ test-ubuntu: &test-ubuntu
   steps:
     - checkout
     - run: cat /etc/*-release
-    - run: apt-get update -qq && apt-get install -y apt-transport-https
+    - run: apt-get update -qq && apt-get install -y apt-transport-https curl
     - run:
         <<: *install-jq
     - run: DIST=ubuntu ./test/test-packages.sh
@@ -19,6 +19,7 @@ test-debian: &test-debian
   steps:
     - checkout
     - run: cat /etc/*-release
+    - run: apt-get update -qq && apt-get install -y curl
     - run:
         <<: *install-jq
     - run: DIST=debian ./test/test-packages.sh
@@ -35,6 +36,7 @@ test-opensuse: &test-opensuse
   steps:
     - checkout
     - run: cat /etc/*-release
+    - run: zypper --quiet --non-interactive update && zypper --non-interactive install curl
     - run:
         <<: *install-jq
     - run: DIST=opensuse ./test/test-packages.sh

--- a/docker/bionic/Dockerfile
+++ b/docker/bionic/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/bionic/Dockerfile
+++ b/docker/bionic/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,9 +1,7 @@
 FROM centos:7
 
-RUN yum update -y -q && \
-    yum install -y \
-    wget
+RUN yum update -y -q
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:7
 
-RUN yum update -y -q
+RUN yum update -y -q && \
+    yum clean all
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -2,7 +2,8 @@ FROM centos:8
 
 RUN dnf upgrade -y -q && \
     dnf install -y \
-    glibc-langpack-en
+    glibc-langpack-en && \
+    dnf clean all
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -2,9 +2,8 @@ FROM centos:8
 
 RUN dnf upgrade -y -q && \
     dnf install -y \
-    glibc-langpack-en \
-    wget
+    glibc-langpack-en
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/focal/Dockerfile
+++ b/docker/focal/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:focal
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/focal/Dockerfile
+++ b/docker/focal/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:focal
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/jessie/Dockerfile
+++ b/docker/jessie/Dockerfile
@@ -2,8 +2,8 @@ FROM debian:jessie
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/jessie/Dockerfile
+++ b/docker/jessie/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:jessie
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/opensuse15/Dockerfile
+++ b/docker/opensuse15/Dockerfile
@@ -2,7 +2,8 @@ FROM opensuse/leap:15.0
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    curl
+    curl && \
+    zypper clean --all
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/opensuse15/Dockerfile
+++ b/docker/opensuse15/Dockerfile
@@ -2,8 +2,8 @@ FROM opensuse/leap:15.0
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/opensuse152/Dockerfile
+++ b/docker/opensuse152/Dockerfile
@@ -2,8 +2,8 @@ FROM opensuse/leap:15.2
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/opensuse152/Dockerfile
+++ b/docker/opensuse152/Dockerfile
@@ -2,7 +2,8 @@ FROM opensuse/leap:15.2
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    curl
+    curl && \
+    zypper clean --all
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/opensuse153/Dockerfile
+++ b/docker/opensuse153/Dockerfile
@@ -2,8 +2,8 @@ FROM opensuse/leap:15.3
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/opensuse153/Dockerfile
+++ b/docker/opensuse153/Dockerfile
@@ -2,7 +2,8 @@ FROM opensuse/leap:15.3
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    curl
+    curl && \
+    zypper clean --all
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/opensuse42/Dockerfile
+++ b/docker/opensuse42/Dockerfile
@@ -2,7 +2,8 @@ FROM opensuse/leap:42.3
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    curl
+    curl && \
+    zypper clean --all
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/opensuse42/Dockerfile
+++ b/docker/opensuse42/Dockerfile
@@ -2,8 +2,8 @@ FROM opensuse/leap:42.3
 
 RUN zypper --quiet --non-interactive update && \
     zypper --non-interactive install \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/stretch/Dockerfile
+++ b/docker/stretch/Dockerfile
@@ -2,8 +2,8 @@ FROM debian:stretch
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/stretch/Dockerfile
+++ b/docker/stretch/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:stretch
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/trusty/Dockerfile
+++ b/docker/trusty/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:trusty
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/docker/trusty/Dockerfile
+++ b/docker/trusty/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:trusty
 
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/xenial/Dockerfile
+++ b/docker/xenial/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:xenial
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     apt-transport-https \
-    wget
+    curl
 
 # Install jq
-RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq

--- a/docker/xenial/Dockerfile
+++ b/docker/xenial/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:xenial
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     apt-transport-https \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install jq
 RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -5,8 +5,8 @@
   "dependencies": [
     {
       "pre_install": [
-        { "command": "[ $(which google-chrome) ] || apt-get install -y gnupg wget" },
-        { "command": "[ $(which google-chrome) ] || wget -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" },
+        { "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl" },
+        { "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" },
         { "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb" }
       ],
       "packages": [],
@@ -24,7 +24,7 @@
     {
       "pre_install": [
         { "command": "yum install -y which" },
-        { "command": "[ $(which google-chrome) ] || wget -O /tmp/google-chrome.rpm https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm" },
+        { "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.rpm https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm" },
         { "command": "[ $(which google-chrome) ] || yum install -y /tmp/google-chrome.rpm" }
       ],
       "packages": [],


### PR DESCRIPTION
As a suggestion from https://github.com/rstudio/r-system-requirements/pull/91#pullrequestreview-794566068, curl is already preinstalled on some distros, so prefer it to wget.

I found that the Ubuntu, Debian and openSUSE Docker images still needed curl to be manually installed though. But at least this saves some resources in the CentOS tests.