### PR TITLE
Fix regex for mysql server

### DIFF
--- a/rules/mysql.json
+++ b/rules/mysql.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\bmysql\\b"],
+  "patterns": ["\\bmysql.*server\\b"],
   "dependencies": [
     {
       "packages": ["mysql-server"],


### PR DESCRIPTION
I maintain the RMySQL package, which depends on mysql client. However the CI fails because it is trying to install a full mysql server: https://github.com/r-dbi/RMySQL/runs/4505762798?check_suite_focus=true

The current PR makes the regex a bit more specific. It should be harmless because no CRAN package actually depends on mysql-server: https://crandb.r-pkg.org/-/sysreqs

@gaborcsardi 