### PR TITLE
Fix chrome rule if chrome is already installed

### DIFF
--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -11,7 +11,7 @@
       ],
       "packages": [],
       "post_install": [
-        { "command": "[ -e /tmp/google-chrome.deb ] && rm /tmp/google-chrome.deb" }
+        { "command": "rm -f /tmp/google-chrome.deb" }
       ],
       "constraints": [
         {
@@ -29,7 +29,7 @@
       ],
       "packages": [],
       "post_install": [
-        { "command": "[ -e /tmp/google-chrome.rpm ] && rm /tmp/google-chrome.rpm" }
+        { "command": "rm -f /tmp/google-chrome.rpm" }
       ],
       "constraints": [
         {


### PR DESCRIPTION
With the original
```
[ -e /tmp/google-chrome.deb ] && rm /tmp/google-chrome.deb"
```
code, if chrome was already installed, and thus it was not
downloaded to `/tmp/google-chrome.deb`, the post-install
expression returns with a non-zero status, which is considered
a failure.

Fixes https://github.com/r-lib/pak/issues/347