### PR TITLE
Default to python3 on debian/ubuntu

### DIFF
--- a/rules/python.json
+++ b/rules/python.json
@@ -2,7 +2,7 @@
     "patterns": ["\\bpython\\b"],
     "dependencies": [
       {
-        "packages": ["python"],
+        "packages": ["python3"],
         "constraints": [
           {
             "os": "linux",


### PR DESCRIPTION
Currently if a package has `"python"` as a system requirement, CI will install python2, even on the most recent Ubuntu versions. As we all know, python2 is dead and most applications no longer work with python2.

All actively supported versions of Debian/Ubuntu have a good version of python3: 
 - https://packages.ubuntu.com/bionic/python3
 - https://packages.ubuntu.com/focal/python3

I think we should really be using this version, when a package has a sysreq on "python". 

@gaborcsardi 