### PR TITLE
added suitesparse library system requirement.

### DIFF
--- a/rules/suitesparse.json
+++ b/rules/suitesparse.json
@@ -1,0 +1,43 @@
+{
+  "patterns": ["\\bsuitesparse\\b"],
+  "dependencies": [
+    {
+      "packages": ["libsuitesparse-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["suitesparse-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat"
+        }
+      ]
+    }
+  ]
+}

--- a/rules/suitesparse.json
+++ b/rules/suitesparse.json
@@ -23,10 +23,6 @@
         },
         {
           "os": "linux",
-          "distribution": "fedora"
-        },
-        {
-          "os": "linux",
           "distribution": "opensuse"
         },
         {


### PR DESCRIPTION
This is to support the `rbff` package: https://github.com/rdinnager/rbff (and any future packages that might use suitesparse).