### PR TITLE
Update to ICU 69 for openSUSE/SLES 15.3

### DIFF
--- a/rules/libicu.json
+++ b/rules/libicu.json
@@ -43,11 +43,28 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "opensuse"
+          "distribution": "opensuse",
+          "versions": ["42.3", "15.0", "15.2"]
         },
         {
           "os": "linux",
-          "distribution": "sle"
+          "distribution": "sle",
+          "versions": ["12.3", "15.0", "15.2"]
+        }
+      ]
+    },
+    {
+      "packages": ["icu.691-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse",
+          "versions": ["15.3"]
+        },
+        {
+          "os": "linux",
+          "distribution": "sle",
+          "versions": ["15.3"]
         }
       ]
     },


### PR DESCRIPTION
The default ICU library on SUSE 15.3 is now ICU 69 (icu.691-devel) instead of ICU 65 (libicu-devel). Prefer ICU 69 when installing packages like stringi, to prevent conflicts.

For more context, see:
https://github.com/rstudio/r-builds/issues/104
https://lists.suse.com/pipermail/sle-security-updates/2021-December/009908.html