### PR TITLE
Add osmium-tool

### DIFF
--- a/rules/osmium-tool.json
+++ b/rules/osmium-tool.json
@@ -1,0 +1,18 @@
+{
+    "patterns": ["\\bosmium-tool\\b"],
+    "dependencies": [
+      {
+        "packages": ["osmium-tool"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "ubuntu"
+          },
+          {
+            "os": "linux",
+            "distribution": "debian"
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds support for [osmium-tool](https://osmcode.org/osmium-tool/) (for the sake of my rather janky package [{parochial}](https://github.com/stupidpupil/parochial) ).

Unfortunately, I don't believe that osmium is packaged for Red Hat or Centos (although it is packaged for Fedora), or SUSE Linux.

I don't know if there are 'notability' requirements on this project - if there are, I entirely understand if my this doesn't meet them!