### PR TITLE
Update libv8 to libnode on Ubuntu 20+

### DIFF
--- a/rules/v8.json
+++ b/rules/v8.json
@@ -2,11 +2,22 @@
   "patterns": ["\\bv8\\b"],
   "dependencies": [
     {
+      "packages": ["libnode-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["20.04", "22.04"]
+        }
+      ]
+    },
+    {
       "packages": ["libv8-dev"],
       "constraints": [
         {
           "os": "linux",
-          "distribution": "ubuntu"
+          "distribution": "ubuntu",
+          "versions": ["18.04"]
         },
         {
           "os": "linux",


### PR DESCRIPTION
On Ubuntu 20 and above, libv8 is now called libnode. Installed libv8 still works and gets aliased to libnode, but should be updated anyway.
```sh
$ docker run -it --rm ubuntu:focal
$ apt update
$ apt install libv8-dev
Note, selecting 'libnode-dev' instead of 'libv8-dev'
```