### PR TITLE
Fix poppler packages on CentOS/RHEL and SUSE for pdftools

### DIFF
--- a/rules/poppler.json
+++ b/rules/poppler.json
@@ -15,17 +15,22 @@
       ]
     },
     {
-      "packages": ["poppler-devel"],
+      "packages": ["poppler-cpp-devel"],
       "constraints": [
         {
           "os": "linux",
           "distribution": "centos",
-          "versions": ["6", "7"]
+          "versions": ["7"]
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["7"]
         }
       ]
     },
     {
-      "packages": ["poppler-devel"],
+      "packages": ["poppler-cpp-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
         { "command": "dnf config-manager --set-enabled powertools" }
@@ -39,7 +44,7 @@
       ]
     },
     {
-      "packages": ["poppler-devel"],
+      "packages": ["poppler-cpp-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
         { "command": "dnf config-manager --set-enabled crb" }
@@ -52,27 +57,20 @@
       ]
     },
     {
-      "packages": ["poppler"],
+      "packages": ["poppler-cpp-devel"],
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms" }
+      ],
       "constraints": [
         {
           "os": "linux",
           "distribution": "redhat",
-          "versions": ["6", "8"]
+          "versions": ["8"]
         }
       ]
     },
     {
-      "packages": ["poppler-devel"],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "redhat",
-          "versions": ["7"]
-        }
-      ]
-    },
-    {
-      "packages": ["poppler-devel"],
+      "packages": ["poppler-cpp-devel"],
       "pre_install": [
         { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" }
       ],
@@ -85,7 +83,7 @@
       ]
     },
     {
-      "packages": ["libpoppler-cpp0"],
+      "packages": ["libpoppler-devel"],
       "constraints": [
         {
           "os": "linux",


### PR DESCRIPTION
Fix poppler on CentOS/RHEL 7 and 8 and SUSE for the pdftools R package. There are different variants of the poppler package, and we had the wrong one that pdftools needed, which is the poppler C++ library.
```sh
$ yum search poppler | grep devel
poppler-devel.i686 : Libraries and headers for poppler
poppler-devel.x86_64 : Libraries and headers for poppler
poppler-cpp-devel.i686 : Development files for C++ wrapper
poppler-cpp-devel.x86_64 : Development files for C++ wrapper
poppler-glib-devel.i686 : Development files for glib wrapper
poppler-glib-devel.x86_64 : Development files for glib wrapper
poppler-qt-devel.i686 : Development files for Qt4 wrapper
poppler-qt-devel.x86_64 : Development files for Qt4 wrapper
```

Ubuntu was fine, but on CentOS/RHEL, it should be `poppler-cpp-devel`. And on SUSE, it should be `libpoppler-devel`. For SUSE, `libpoppler-devel` possibly did not exist back when openSUSE 15.3 was first released.