### PR TITLE
Add support for sqlite3

### DIFF
--- a/rules/sqlite3.json
+++ b/rules/sqlite3.json
@@ -1,0 +1,48 @@
+{
+  "patterns": ["\\bsqlite3\\b", "\\bsqlite\\b"],
+  "dependencies": [
+    {
+      "packages": ["libsqlite3-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["sqlite-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat"
+        }
+      ]
+    },
+    {
+      "packages": ["sqlite3-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up of https://github.com/rstudio/r-system-requirements/pull/112: adding GDAL for RHEL 9 got a bunch of geospatial packages building, but still not sf.

sf needs sqlite3 as well, which we previously added as an implicit dependency of GDAL because sf did not specify it in SystemRequirements (https://github.com/rstudio/r-system-requirements/pull/54). sf now has `sqlite3` in its SystemRequirements, so we can add a proper rule for sqlite3.