### PR TITLE
Fix V8 on Fedora 38

### DIFF
--- a/rules/v8.json
+++ b/rules/v8.json
@@ -30,7 +30,18 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "fedora"
+          "distribution": "fedora",
+          "versions": [ "36", "37" ]
+        }
+      ]
+    },
+    {
+      "packages": ["v8-10.2-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "fedora",
+          "versions": [ "38" ]
         }
       ]
     },


### PR DESCRIPTION
They have two versions of V8 now, this is one of them.