### PR TITLE
Fedora: support aliases in tests

### DIFF
--- a/rules/v8.json
+++ b/rules/v8.json
@@ -30,18 +30,7 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "fedora",
-          "versions": [ "36", "37" ]
-        }
-      ]
-    },
-    {
-      "packages": ["v8-10.2-devel"],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "fedora",
-          "versions": [ "38" ]
+          "distribution": "fedora"
         }
       ]
     },

--- a/test/test-packages.sh
+++ b/test/test-packages.sh
@@ -100,7 +100,10 @@ test_package_fedora() {
     printf "$pkg | "
     # We only use the local cache, because metadata queries are slow,
     # especially for rawhide
-    found=$(yum -C list -q "$pkg")
+    found=$(yum -Cq repoquery --whatprovides "$pkg")
+    if [[ -z "$found" ]]; then
+	exit 1
+    fi
     echo $found
 }
 


### PR DESCRIPTION
We could probably do this in the other RPM
distros as well.

Also update the Fedora rule to use the alias,
now that we support it.