### PR TITLE
Update README for CentOS 8 EOL and Rocky Linux 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,17 @@ Both tests run with R 3.5.3 for all CRAN packages as of April 4, 2019.
 The rules in this catalog support the following operating systems:
 
 - Ubuntu 18.04, 20.04, 22.04
-- CentOS 7, 8
-- Rocky Linux 9
+- CentOS 7
+- Rocky Linux 8*, 9
 - Red Hat Enterprise Linux 7, 8, 9
 - openSUSE 15.3, 15.4
 - SUSE Linux Enterprise 15 SP3, 15 SP4
 - Debian 10, 11, unstable
 - Fedora 36, 37, 38
 - Windows (for R 4.0+ only)
+
+\* Rocky Linux 8 is specified as `centos8` for backward compatibility.
+CentOS 8 reached end of support on December 31, 2021.
 
 ---
 
@@ -287,7 +290,7 @@ Available tags:
 - `bullseye` (Debian 11)
 - `sid` (Debian unstable)
 - `centos7` (CentOS 7)
-- `centos8` (CentOS 8)
+- `centos8` (Rocky Linux 8)
 - `rockylinux9` (Rocky Linux 9)
 - `opensuse153` (openSUSE 15.3)
 - `opensuse154` (openSUSE 15.4)


### PR DESCRIPTION
For https://github.com/rstudio/r-system-requirements/issues/126 - remove CentOS 8, add Rocky Linux 8, and note that Rocky 8 is still `centos8` for backward compatiiblity.