### PR TITLE
Fix igraph on RHEL 9; add required CRB repo for glpk-devel on RHEL 9

### DIFF
--- a/rules/glpk.json
+++ b/rules/glpk.json
@@ -64,6 +64,8 @@
     {
       "packages": ["glpk-devel"],
       "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled crb" },
         { "command": "dnf install -y epel-release" }
       ],
       "constraints": [
@@ -106,6 +108,7 @@
     {
       "packages": ["glpk-devel"],
       "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" },
         { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
       ],
       "constraints": [


### PR DESCRIPTION
glpk-devel on RHEL/Rocky Linux 9 needs the CRB repo in addition to EPEL.

```sh
docker run -it --rm rstudio/r-base:4.3-rockylinux9 bash
dnf install -y epel-release
dnf install -y glpk-devel

# ...
# Many EPEL packages require the CodeReady Builder (CRB) repository.
# It is recommended that you run /usr/bin/crb enable to enable the CRB repository.

#   Verifying        : epel-release-9-4.el9.noarch                                                                                                       1/1 

# Installed:
#   epel-release-9-4.el9.noarch                                                                                                                              

# Complete!
# Extra Packages for Enterprise Linux 9 - x86_64                                                                             4.6 MB/s |  16 MB     00:03    
# Last metadata expiration check: 0:00:04 ago on Thu 25 May 2023 07:33:28 PM UTC.
# Error: 
#  Problem: package suitesparse-5.4.0-10.el9.x86_64 requires libopenblas.so.0()(64bit), but none of the providers can be installed
#   - package openblas-serial-0.3.21-2.el9.x86_64 requires openblas = 0.3.21-2.el9, but none of the providers can be installed
#   - package glpk-5.0-6.el9.x86_64 requires libamd.so.2()(64bit), but none of the providers can be installed
#   - package glpk-5.0-6.el9.x86_64 requires libcolamd.so.2()(64bit), but none of the providers can be installed
#   - cannot install both openblas-0.3.21-2.el9.x86_64 and openblas-0.3.15-3.el9.x86_64
#   - package glpk-devel-5.0-6.el9.x86_64 requires libglpk.so.40()(64bit), but none of the providers can be installed
#   - package glpk-devel-5.0-6.el9.x86_64 requires glpk(x86-64) = 5.0-6.el9, but none of the providers can be installed
#   - package openblas-openmp64-0.3.15-3.el9.x86_64 requires openblas = 0.3.15-3.el9, but none of the providers can be installed
#   - conflicting requests
#   - problem with installed package openblas-openmp64-0.3.15-3.el9.x86_64
# (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

```sh
docker run -it --rm rstudio/r-base:4.3-rockylinux9 bash
dnf install -y epel-release
dnf config-manager --set-enabled crb
dnf install -y glpk-devel

# ...
# Upgraded:
#   openblas-0.3.21-2.el9.x86_64                  openblas-openmp-0.3.21-2.el9.x86_64                  openblas-openmp64-0.3.21-2.el9.x86_64                 
# Installed:
#   glpk-5.0-6.el9.x86_64   glpk-devel-5.0-6.el9.x86_64   openblas-serial-0.3.21-2.el9.x86_64   suitesparse-5.4.0-10.el9.x86_64   tbb-2020.3-8.el9.x86_64  

# Complete!
```