### PR TITLE
OpenBabel & Eigen3

### DIFF
--- a/rules/eigen.json
+++ b/rules/eigen.json
@@ -1,0 +1,18 @@
+{
+  "patterns": ["\\beigen3?\\b"],
+  "dependencies": [
+    {
+      "packages": ["libeigen3-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    }
+  ]
+}

--- a/rules/openbabel.json
+++ b/rules/openbabel.json
@@ -1,0 +1,18 @@
+{
+  "patterns": ["\\bopenbabel\\b"],
+  "dependencies": [
+    {
+      "packages": ["libopenbabel-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
OpenBabel and Eigen3 are system requriements of the BioConductor package [`ChemmineOB`](https://github.com/girke-lab/ChemmineOB/blob/5bf48b55125cb8dfaad6391b868b8ea7bc3c14a9/DESCRIPTION#LL13C21-L13C99).