### PR TITLE
Fix eigen3 and openbabel for RPM distros

### DIFF
--- a/rules/eigen.json
+++ b/rules/eigen.json
@@ -60,7 +60,7 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux",
+          "distribution": "centos",
           "versions": ["8"]
         },
         {

--- a/rules/eigen.json
+++ b/rules/eigen.json
@@ -62,7 +62,15 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
-        },
+        }
+      ]
+    },
+    {
+      "packages": ["eigen3-devel"],
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms" }
+      ],
+      "constraints": [
         {
           "os": "linux",
           "distribution": "redhat",
@@ -81,7 +89,15 @@
           "os": "linux",
           "distribution": "rockylinux",
           "versions": ["9"]
-        },
+        }
+      ]
+    },
+    {
+      "packages": ["eigen3-devel"],
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" }
+      ],
+      "constraints": [
         {
           "os": "linux",
           "distribution": "redhat",

--- a/rules/eigen.json
+++ b/rules/eigen.json
@@ -13,6 +13,81 @@
           "distribution": "debian"
         }
       ]
+    },
+    {
+      "packages": ["eigen3-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    },
+    {
+      "packages": ["eigen3-devel"],
+      "pre_install": [
+        {
+          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["7"]
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["7"]
+        }
+      ]
+    },
+    {
+      "packages": ["eigen3-devel"],
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "packages": ["eigen3-devel"],
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled crb" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["9"]
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["9"]
+        }
+      ]
     }
   ]
 }

--- a/rules/openbabel.json
+++ b/rules/openbabel.json
@@ -64,10 +64,32 @@
         {
           "os": "linux",
           "distribution": "rockylinux"
-        },
+        }
+      ]
+    },
+    {
+      "packages": ["openbabel-devel"],
+      "pre_install": [
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm" }
+      ],
+      "constraints": [
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "redhat",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "packages": ["openbabel-devel"],
+      "pre_install": [
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["9"]
         }
       ]
     }

--- a/rules/openbabel.json
+++ b/rules/openbabel.json
@@ -13,6 +13,59 @@
           "distribution": "debian"
         }
       ]
+    },
+    {
+      "packages": ["openbabel-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    },
+    {
+      "packages": ["openbabel-devel"],
+      "pre_install": [
+        {
+          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["7"]
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["7"]
+        }
+      ]
+    },
+    {
+      "packages": ["openbabel-devel"],
+      "pre_install": [
+        { "command": "dnf install -y epel-release" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat"
+        }
+      ]
     }
   ]
 }

--- a/rules/openbabel.json
+++ b/rules/openbabel.json
@@ -59,6 +59,10 @@
       "constraints": [
         {
           "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
           "distribution": "rockylinux"
         },
         {

--- a/rules/openbabel.json
+++ b/rules/openbabel.json
@@ -59,7 +59,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["8"]
         },
         {
           "os": "linux",


### PR DESCRIPTION
I assumed that RHEL 7 follows CentOS 7, and RHEL 8 & 9 follow Rocky Linux (but we call it centos 8 instead of rockylinux 8). But I am not entirely sure if this is the case.