### PR TITLE
DEB: support virtual packages and constraints

### DIFF
--- a/rules/libcurl.json
+++ b/rules/libcurl.json
@@ -3,6 +3,7 @@
   "dependencies": [
     {
       "packages": ["libcurl4-openssl-dev"],
+      "satisfy": ["libcurl4-openssl-dev | libcurl4-dev"],
       "constraints": [
         {
           "os": "linux",

--- a/rules/libcurl.json
+++ b/rules/libcurl.json
@@ -3,7 +3,7 @@
   "dependencies": [
     {
       "packages": ["libcurl4-openssl-dev"],
-      "satisfy": ["libcurl4-openssl-dev | libcurl4-dev"],
+      "apt_satisfy": ["libcurl4-openssl-dev | libcurl4-dev"],
       "constraints": [
         {
           "os": "linux",

--- a/schema.json
+++ b/schema.json
@@ -74,6 +74,13 @@
               "minLength": 1
             }
           },
+          "satisfy": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
           "constraints": {
             "type": "array",
             "minItems": 1,

--- a/schema.json
+++ b/schema.json
@@ -74,7 +74,7 @@
               "minLength": 1
             }
           },
-          "satisfy": {
+          "apt_satisfy": {
             "type": "array",
             "items": {
               "type": "string",

--- a/schema.template.json
+++ b/schema.template.json
@@ -74,6 +74,13 @@
               "minLength": 1
             }
           },
+          "satisfy": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
           "constraints": {
             "type": "array",
             "minItems": 1,

--- a/schema.template.json
+++ b/schema.template.json
@@ -74,7 +74,7 @@
               "minLength": 1
             }
           },
-          "satisfy": {
+          "apt_satisfy": {
             "type": "array",
             "items": {
               "type": "string",

--- a/test/test-packages.sh
+++ b/test/test-packages.sh
@@ -166,7 +166,7 @@ test_packages() {
             # Run any pre-install commands (e.g. adding a repo)
             pre_install_cmds=$(echo "$dep" | jq ".pre_install[]?")
             pkgs=$(echo "$dep" | jq -r ".packages[]")
-            sats=$(echo "$dep" | jq -r ".satisfy[]?")
+            sats=$(echo "$dep" | jq -r ".apt_satisfy[]?")
             jq -c <<< "$pre_install_cmds" | while read cmd; do
                 run_extra_cmd "$cmd"
             done


### PR DESCRIPTION
From Debian 11 and Ubuntu 20.04, there is an `apt-get satisfy` subcommand that works with virtual packages and general constraints, so it is much more flexible than `apt-get install`.

We can use this to specify a preferred variant of a virtual package, but still be able to fall back to another variant.

This is sometimes needed to avoid conflicts. E.g. R packages that need Redland (`librdf0-dev` on Ubuntu), conflict with the curl R packages for which we require `libcurl4-openssl-dev` on Ubuntu. This clearly does not work with `apt-get install`:
```
root@974a41c99f81:~# apt-get install libcurl4-openssl-dev librdf0-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libraptor2-dev : Depends: libcurl4-gnutls-dev but it is not installable
E: Unable to correct problems, you have held broken packages.
```

But if we depend on the a constraint with a fallback instead:
```
libcurl4-openssl-dev | libcurl4-dev
```
then we can easily install both R packages after `apt-get satisfy`:
```
root@974a41c99f81:~# apt-get satisfy 'libcurl4-openssl-dev | libcurl4-dev' librdf0-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
[...]
```

I suggest that we keep the `packages` field as is, for compatibility, but also add another field called `satisfy` (not a great name, feel free to change it), which takes an array of constraints. Then smarter clients, and possibly the PPM API iteself, can use `apt-get satisfy` with the constraints, on systems that support them.