### PR TITLE
add Boost support

### DIFF
--- a/rules/boost.json
+++ b/rules/boost.json
@@ -1,0 +1,27 @@
+{
+    "patterns": ["\\Boost\\b"],
+    "dependencies": [
+      {
+        "packages": ["libboost-all-dev"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "ubuntu"
+          },
+          {
+            "os": "linux",
+            "distribution": "debian"
+          }
+        ]
+      },
+      {
+        "packages": ["boost-devel"],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "fedora"
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds support for Boost on Debian/Ubuntu and Fedora.
It seems that Boost is required by some packages on CRAN: https://github.com/search?q=org%3Acran+boost+path%3ADESCRIPTION&type=code 

It seems that it's also installed by default on some CRAN machines.

