### PR TITLE
Add flint support

### DIFF
--- a/rules/flint.json
+++ b/rules/flint.json
@@ -1,0 +1,31 @@
+{
+  "patterns": ["\\bflint\\b"],
+  "dependencies": [
+    {
+      "packages": ["libflint-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["flint-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for [FLINT (Fast Library for Number Theory)](https://flintlib.org).

Currently the library is in Debian, Ubuntu, OpenSUSE and Fedora, but not in RHEL type distros, including CentOS or Rocky.

The library is [currently in testing branch](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/flint-dev) of Alpine, so we will need to wait for release.

I've confirmed that `make test-all RULES=rules/flint.json` passes with no errors.
