### PR TITLE
Add libssh rule

### DIFF
--- a/rules/libssh.json
+++ b/rules/libssh.json
@@ -1,0 +1,105 @@
+{
+  "patterns": ["\\blibssh\\b"],
+  "dependencies": [
+    {
+      "packages": ["libssh-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["libssh-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        }
+      ]
+    },
+    {
+      "packages": ["libssh-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["6", "7"]
+        }
+      ]
+    },
+    {
+      "packages": ["libssh-devel"],
+      "pre_install": [
+        { "command": "dnf install -y epel-release" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux"
+        }
+      ]
+    },
+    {
+      "packages": ["libssh"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["7", "8"]
+        }
+      ]
+    },
+    {
+      "packages": ["libssh-devel"],
+      "pre_install": [
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["libopenssl-devel", "libssh-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    },
+    {
+      "packages": ["libssh-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
+    },
+    {
+      "packages": [
+        "mingw-w64-x86_64-libssh",
+        "mingw-w64-i686-libssh"
+      ],
+      "constraints": [
+        {
+          "os": "windows"
+        }
+      ]
+    }
+  ]
+}

--- a/rules/libssh.json
+++ b/rules/libssh.json
@@ -69,7 +69,7 @@
       ]
     },
     {
-      "packages": ["libopenssl-devel", "libssh-devel"],
+      "packages": ["libssh-devel"],
       "constraints": [
         {
           "os": "linux",


### PR DESCRIPTION
This will add a rule for libssh

Noticed an issue when trying to run a build which requires the R package https://github.com/ropensci/ssh
Example error here https://github.com/mrc-ide/hintr/actions/runs/8172298442/job/22342313071#step:5:7594

This is because ssh package requires libssh, not libssh2 as mentioned in the [DESCRIPTION](https://github.com/ropensci/ssh/blob/master/DESCRIPTION#L12). This is pulling in libssh2 because DESCRIPTION text mentions libssh2.

After this PR should see in the tests `plumberDeploy` and `ssh` matching this new rule. 

They are both still matched by libssh2 rule, but that's probably something that should be fixed in the package DESCRIPTION