### PR TITLE
Add grpc, grpc plugins for bigrquerystorage package

### DIFF
--- a/rules/grpcpp.json
+++ b/rules/grpcpp.json
@@ -1,0 +1,77 @@
+{
+  "patterns": ["\\blibgrpc\\+\\+"],
+  "dependencies": [
+    {
+      "packages": ["libgrpc++-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "destribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-devel", "pkgconf"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "yum install -y epel-release" },
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled crb" }
+      ],
+      "packages": ["grpc-devel", "pkgconf"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "version": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-devel", "pkgconf"],
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
+    }
+  ]
+}

--- a/rules/grpcpp.json
+++ b/rules/grpcpp.json
@@ -10,7 +10,7 @@
         },
         {
           "os": "linux",
-          "destribution": "debian"
+          "distribution": "debian"
         }
       ]
     },
@@ -34,7 +34,7 @@
         {
           "os": "linux",
           "distribution": "rockylinux",
-          "version": ["9"]
+          "versions": ["9"]
         }
       ]
     },

--- a/rules/protobuf-grpc.json
+++ b/rules/protobuf-grpc.json
@@ -69,7 +69,18 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "alpine"
+          "distribution": "alpine",
+          "versions": ["3.17", "3.18", "3.19", "edge"]
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine",
+          "versions": ["3.16"]
         }
       ]
     }

--- a/rules/protobuf-grpc.json
+++ b/rules/protobuf-grpc.json
@@ -10,7 +10,7 @@
         },
         {
           "os": "linux",
-          "destribution": "debian"
+          "distribution": "debian"
         }
       ]
     },
@@ -34,7 +34,7 @@
         {
           "os": "linux",
           "distribution": "rockylinux",
-          "version": ["9"]
+          "versions": ["9"]
         }
       ]
     },

--- a/rules/protobuf-grpc.json
+++ b/rules/protobuf-grpc.json
@@ -1,0 +1,77 @@
+{
+  "patterns": ["\\bgrpc/protobuf\\b"],
+  "dependencies": [
+    {
+      "packages": ["protobuf-compiler-grpc"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "destribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-plugins"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "yum install -y epel-release" },
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled crb" }
+      ],
+      "packages": ["grpc-plugins"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "version": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-plugins"],
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["grpc-plugins"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
AFAICT there is no grpc for centos 7, rhel 6-8 and rocky 8.

Closes https://github.com/meztez/bigrquerystorage/issues/49