### PR TITLE
RProtobuf needs libprotoc-dev on Ubuntu/Debian

### DIFF
--- a/rules/protobuf-compiler.json
+++ b/rules/protobuf-compiler.json
@@ -2,7 +2,7 @@
   "patterns": ["\\bprotobuf-compiler\\b"],
   "dependencies": [
     {
-      "packages": ["protobuf-compiler"],
+      "packages": ["protobuf-compiler", "libprotoc-dev"],
       "constraints": [
         {
           "os": "linux",


### PR DESCRIPTION
Apparently. The other distros should be fine as is.

I guess this is why we do not have an RProtoBuf binary on PPM.