### PR TITLE
Fix Chrome and tests on CentOS 7

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:7
 
+# Use vault.centos.org since CentOS 7 is EOL and the official mirrors are no longer available
+RUN sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*
+
 RUN yum update -y -q
 
 # Install jq

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -37,7 +37,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "centos"
+          "distribution": "centos",
+          "versions": ["8"]
         },
         {
           "os": "linux",
@@ -45,12 +46,36 @@
         },
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "redhat",
+          "versions": ["8"]
         },
         {
           "os": "linux",
           "distribution": "fedora",
           "versions": [ "36", "37" ]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "yum install -y which" },
+        { "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.rpm https://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-125.0.6422.141-1.x86_64.rpm" },
+        { "command": "[ $(which google-chrome) ] || yum install -y /tmp/google-chrome.rpm" }
+      ],
+      "packages": [],
+      "post_install": [
+        { "command": "rm -f /tmp/google-chrome.rpm" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["7"]
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["7"]
         }
       ]
     },


### PR DESCRIPTION
* CentOS 7 is EOL and now needs vault.centos.org for mirrors
* Chrome 126 and later no longer support CentOS 7, pin to version 125
```sh
# Chrome 127
$ yum install -y /tmp/google-chrome.rpm 
Error: Invalid version flag: or

# Chrome 126
Error: Package: google-chrome-stable-126.0.6478.182-1.x86_64 (/google-chrome-stable-126.0.6478.182-1.x86_64)
           Requires: libc.so.6(GLIBC_2.25)(64bit)
```