### PR TITLE
Use `postgresql-devel` instead of `postgresql-server-devel` on redhat-8

### DIFF
--- a/rules/postgresql.json
+++ b/rules/postgresql.json
@@ -25,12 +25,12 @@
         {
           "os": "linux",
           "distribution": "redhat",
-          "versions": ["6", "7", "8"]
+          "versions": ["6", "7"]
         }
       ]
     },
     {
-      "packages": ["postgresql-server-devel"],
+      "packages": ["libpq-devel"],
       "constraints": [
         {
           "os": "linux",
@@ -39,33 +39,16 @@
         },
         {
           "os": "linux",
-          "distribution": "fedora"
-        }
-      ]
-    },
-    {
-      "packages": ["postgresql-server-devel"],
-      "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled crb" }
-      ],
-      "constraints": [
+          "distribution": "redhat",
+          "versions": ["8", "9"]
+        },
         {
           "os": "linux",
           "distribution": "rockylinux"
-        }
-      ]
-    },
-    {
-      "packages": ["postgresql-server-devel"],
-      "pre_install": [
-        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" }
-      ],
-      "constraints": [
+        },
         {
           "os": "linux",
-          "distribution": "redhat",
-          "versions": ["9"]
+          "distribution": "fedora"
         }
       ]
     },

--- a/rules/postgresql.json
+++ b/rules/postgresql.json
@@ -25,7 +25,7 @@
         {
           "os": "linux",
           "distribution": "redhat",
-          "versions": ["6", "7"]
+          "versions": ["6", "7", "8"]
         }
       ]
     },
@@ -35,11 +35,6 @@
         {
           "os": "linux",
           "distribution": "centos",
-          "versions": ["8"]
-        },
-        {
-          "os": "linux",
-          "distribution": "redhat",
           "versions": ["8"]
         },
         {


### PR DESCRIPTION
At the moment, the system dependency `postgresql-devel` is mapped to  `postgresql-server-devel` on `redhat-8`:

```
RPostgres    1.4.7 [bld][cmp][dl] (1.47 MB) + ✖ postgresql-server-devel
```

However, on rhel8 actually `postgresql-devel` is required to successfully install `RPostgres`:

```* installing *source* package ‘RPostgres’ ...
** package ‘RPostgres’ successfully unpacked and MD5 sums checked
** using staged installation
Using PKG_CFLAGS=
Using PKG_LIBS=-lpq
Using PKG_PLOGR=
------------------------- ANTICONF ERROR ---------------------------
Configuration failed because libpq was not found. Try installing:
 * deb: libpq-dev libssl-dev (Debian, Ubuntu, etc)
 * rpm: postgresql-devel (Fedora, EPEL)
 * rpm: postgreql8-devel, postgresql92-devel, postgresql93-devel, or postgresql94-devel (Amazon Linux)
 * csw: postgresql_dev (Solaris)
 * brew: libpq (OSX)
```

Installing `postgresql-devel` also makes the installation work. Hence, I propose that the current mapping should be changed so that `postgresql-devel` is installed instead of `postgresql-server-devel`.

Tested in a new `redhat/ubi8` container.

```
cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="8.10 (Ootpa)"
```