### PR TITLE
Fix imagemagick rules for RHEL

### DIFF
--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -56,7 +56,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++", "ImageMagick-c++-devel", "ImageMagick-devel"],
+        "packages": ["ImageMagick-c++-devel", "ImageMagick-devel"],
         "constraints": [
           {
             "os": "linux",

--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -56,7 +56,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++"],
+        "packages": ["ImageMagick", "ImageMagick-c++", "ImageMagick-c++-devel", "ImageMagick-devel"],
         "constraints": [
           {
             "os": "linux",
@@ -66,7 +66,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++"],
+        "packages": ["ImageMagick", "ImageMagick-c++", "ImageMagick-c++-devel", "ImageMagick-devel"],
         "pre_install": [
           {
             "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
@@ -81,7 +81,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++"],
+        "packages": ["ImageMagick", "ImageMagick-c++", "ImageMagick-c++-devel", "ImageMagick-devel"],
         "pre_install": [
           { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
         ],

--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -2,7 +2,7 @@
     "patterns": ["\\bimagemagick\\b", "\\bimage magick\\b"],
     "dependencies": [
       {
-        "packages": ["imagemagick", "libmagick++-dev", "gsfonts"],
+        "packages": ["imagemagick-dev", "libmagick++-dev", "gsfonts"],
         "constraints": [
           {
             "os": "linux",
@@ -15,7 +15,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++-devel"],
+        "packages": ["ImageMagick-devel", "ImageMagick-c++-devel"],
         "constraints": [
           {
             "os": "linux",
@@ -29,7 +29,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++-devel"],
+        "packages": ["ImageMagick-devel", "ImageMagick-c++-devel"],
         "pre_install": [
           { "command": "dnf install -y dnf-plugins-core" },
           { "command": "dnf config-manager --set-enabled powertools" },
@@ -44,7 +44,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++-devel"],
+        "packages": ["ImageMagick-devel", "ImageMagick-c++-devel"],
         "pre_install": [
           { "command": "dnf install -y epel-release" }
         ],
@@ -66,7 +66,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++", "ImageMagick-c++-devel", "ImageMagick-devel"],
+        "packages": ["ImageMagick-c++-devel", "ImageMagick-devel"],
         "pre_install": [
           {
             "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
@@ -81,7 +81,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-c++", "ImageMagick-c++-devel", "ImageMagick-devel"],
+        "packages": ["ImageMagick-c++-devel", "ImageMagick-devel"],
         "pre_install": [
           { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
         ],
@@ -94,7 +94,7 @@
         ]
       },
       {
-        "packages": ["ImageMagick", "ImageMagick-devel", "libMagick++-devel"],
+        "packages": ["ImageMagick-devel", "libMagick++-devel"],
         "constraints": [
           {
             "os": "linux",

--- a/rules/imagemagick.json
+++ b/rules/imagemagick.json
@@ -2,7 +2,7 @@
     "patterns": ["\\bimagemagick\\b", "\\bimage magick\\b"],
     "dependencies": [
       {
-        "packages": ["imagemagick-dev", "libmagick++-dev", "gsfonts"],
+        "packages": ["libmagick++-dev", "gsfonts"],
         "constraints": [
           {
             "os": "linux",


### PR DESCRIPTION
RHEL distros need `ImageMagick-c++-devel"`, see also https://cran.r-project.org/web/packages/magick/index.html.

`ImageMagick-devel` is installed as a dep or vice-versa, given that `ImageMagick` is already listed, I included it as well.