### PR TITLE
Use `chromium` instead of a manual chrome download

### DIFF
--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -18,9 +18,9 @@
     },
     {
       "pre_install": [
-        {
-          "command": "dnf install -y epel-release"
-        }
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled crb" },
+        { "command": "dnf install -y epel-release" }
       ],
       "packages": ["chromium"],
       "post_install": [],
@@ -28,13 +28,35 @@
         {
           "os": "linux",
           "distribution": "rockylinux"
-        },
+        }
+    },
+    {
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms" },
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm" }
+      ],
+      "packages": ["chromium"],
+      "post_install": [],
+      "constraints": [
         {
           "os": "linux",
-          "distribution": "redhat",
-          "versions": ["8", "9"]
+          "distribution": "redhat"
+          "versions": ["8"]
         }
-      ]
+    },
+    {
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" },
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
+      ],
+      "packages": ["chromium"],
+      "post_install": [],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat"
+          "versions": ["9"]
+        }
     },
     {
       "pre_install": [],

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -32,7 +32,7 @@
         {
           "os": "linux",
           "distribution": "redhat",
-          "version": ["8", "9"]
+          "versions": ["8", "9"]
         }
       ]
     },

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -56,7 +56,7 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["7", "8"]
-        },
+        }
       ]
     }
   ]

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -5,9 +5,9 @@
   ],
   "dependencies": [
     {
-      "pre_install": "",
+      "pre_install": [],
       "packages": ["chromium"],
-      "post_install": "",
+      "post_install": [],
       "constraints": [
         {
           "os": "linux",

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -13,10 +13,26 @@
           "os": "linux",
           "distribution": "ubuntu",
           "versions": ["20.04", "22.04"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        {
+          "command": "dnf install -y epel-release"
+        }
+      ],
+      "packages": ["chromium"],
+      "post_install": [],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux"
         },
         {
           "os": "linux",
-          "distribution": "debian"
+          "distribution": "redhat",
+          "version": ["8", "9"]
         }
       ]
     },
@@ -27,15 +43,11 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "debian"
         },
         {
           "os": "linux",
           "distribution": "fedora"
-        },
-        {
-          "os": "linux",
-          "distribution": "rockylinux"
         },
         {
           "os": "linux",

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -12,7 +12,7 @@
         {
           "os": "linux",
           "distribution": "ubuntu",
-          "versions": ["focal", "jammy"]
+          "versions": ["20.04", "22.04"]
         },
         {
           "os": "linux",

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -17,7 +17,9 @@
         {
           "os": "linux",
           "distribution": "debian"
-        },
+        }
+      ]
+    },
     {
       "pre_install": [],
       "packages": ["chromium"],

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -29,6 +29,7 @@
           "os": "linux",
           "distribution": "rockylinux"
         }
+      ]
     },
     {
       "pre_install": [
@@ -43,6 +44,7 @@
           "distribution": "redhat",
           "versions": ["8"]
         }
+      ]
     },
     {
       "pre_install": [
@@ -57,6 +59,7 @@
           "distribution": "redhat",
           "versions": ["9"]
         }
+      ]
     },
     {
       "pre_install": [],

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -40,7 +40,7 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "redhat",
           "versions": ["8"]
         }
     },
@@ -54,7 +54,7 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "redhat"
+          "distribution": "redhat",
           "versions": ["9"]
         }
     },

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -35,7 +35,7 @@
         {
           "os": "linux",
           "distribution": "ubuntu",
-          "versions": "20.04"
+          "versions": ["20.04"]
         }
       ]
     },

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -77,6 +77,11 @@
         {
           "os": "linux",
             "distribution": "alpine"
+        },
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["24.04"]
         }
       ]
     },

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -1,18 +1,13 @@
 {
   "patterns": [
-    "\\bchrome\\b"
+    "\\bchrome\\b",
+    "\\bchromium\\b"
   ],
   "dependencies": [
     {
-      "pre_install": [
-        { "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl" },
-        { "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" },
-        { "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb" }
-      ],
-      "packages": [],
-      "post_install": [
-        { "command": "rm -f /tmp/google-chrome.deb" }
-      ],
+      "pre_install": "",
+      "packages": ["chromium"],
+      "post_install": "",
       "constraints": [
         {
           "os": "linux",
@@ -21,24 +16,18 @@
         {
           "os": "linux",
           "distribution": "debian"
-        }
-      ]
-    },
-    {
-      "pre_install": [
-        { "command": "yum install -y which" },
-        { "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.rpm https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm" },
-        { "command": "[ $(which google-chrome) ] || yum install -y /tmp/google-chrome.rpm" }
-      ],
-      "packages": [],
-      "post_install": [
-        { "command": "rm -f /tmp/google-chrome.rpm" }
-      ],
-      "constraints": [
+        },
         {
           "os": "linux",
-          "distribution": "centos",
-          "versions": ["8"]
+          "distribution": "redhat"
+        },
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "centos"
         },
         {
           "os": "linux",
@@ -46,13 +35,7 @@
         },
         {
           "os": "linux",
-          "distribution": "redhat",
-          "versions": ["8"]
-        },
-        {
-          "os": "linux",
-          "distribution": "fedora",
-          "versions": [ "36", "37" ]
+            "distribution": "alpine"
         }
       ]
     },
@@ -76,15 +59,6 @@
           "os": "linux",
           "distribution": "redhat",
           "versions": ["7"]
-        }
-      ]
-    },
-    {
-      "packages": ["chromium"],
-      "constraints": [
-        {
-          "os": "linux",
-            "distribution": "alpine"
         }
       ]
     }

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -11,7 +11,7 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "ubuntu"
+          "distribution": "ubuntu",
           "versions": ["focal", "jammy"]
         },
         {
@@ -30,10 +30,6 @@
         {
           "os": "linux",
           "distribution": "fedora"
-        },
-        {
-          "os": "linux",
-          "distribution": "centos"
         },
         {
           "os": "linux",
@@ -61,11 +57,6 @@
           "distribution": "centos",
           "versions": ["7", "8"]
         },
-        {
-          "os": "linux",
-          "distribution": "redhat",
-          "versions": ["7", "8"]
-        }
       ]
     }
   ]

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -6,17 +6,23 @@
   "dependencies": [
     {
       "pre_install": [],
-      "packages": ["chromium"],
+      "packages": ["chromium-browser"],
       "post_install": [],
       "constraints": [
         {
           "os": "linux",
           "distribution": "ubuntu"
+          "versions": ["focal", "jammy"]
         },
         {
           "os": "linux",
           "distribution": "debian"
         },
+    {
+      "pre_install": [],
+      "packages": ["chromium"],
+      "post_install": [],
+      "constraints": [
         {
           "os": "linux",
           "distribution": "redhat"
@@ -53,12 +59,12 @@
         {
           "os": "linux",
           "distribution": "centos",
-          "versions": ["7"]
+          "versions": ["7", "8"]
         },
         {
           "os": "linux",
           "distribution": "redhat",
-          "versions": ["7"]
+          "versions": ["7", "8"]
         }
       ]
     }

--- a/rules/chrome.json
+++ b/rules/chrome.json
@@ -1,18 +1,41 @@
 {
-  "patterns": [
-    "\\bchrome\\b",
-    "\\bchromium\\b"
-  ],
+  "patterns": ["\\bchrome\\b", "\\bchromium\\b"],
   "dependencies": [
     {
-      "pre_install": [],
-      "packages": ["chromium-browser"],
+      "pre_install": [
+        { "command": "apt-get install -y software-properties-common" },
+        { "command": "add-apt-repository -y ppa:xtradeb/apps" },
+        { "command": "apt-get update" }
+      ],
+      "packages": ["chromium"],
       "post_install": [],
       "constraints": [
         {
           "os": "linux",
           "distribution": "ubuntu",
-          "versions": ["20.04", "22.04"]
+          "versions": ["22.04", "24.04"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        {
+          "command": "[ $(which google-chrome) ] || apt-get install -y gnupg curl"
+        },
+        {
+          "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+        },
+        {
+          "command": "[ $(which google-chrome) ] || DEBIAN_FRONTEND='noninteractive' apt-get install -y /tmp/google-chrome.deb"
+        }
+      ],
+      "packages": [],
+      "post_install": [{ "command": "rm -f /tmp/google-chrome.deb" }],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": "20.04"
         }
       ]
     },
@@ -33,8 +56,12 @@
     },
     {
       "pre_install": [
-        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms" },
-        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm" }
+        {
+          "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms"
+        },
+        {
+          "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+        }
       ],
       "packages": ["chromium"],
       "post_install": [],
@@ -48,8 +75,12 @@
     },
     {
       "pre_install": [
-        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" },
-        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
+        {
+          "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms"
+        },
+        {
+          "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+        }
       ],
       "packages": ["chromium"],
       "post_install": [],
@@ -76,25 +107,22 @@
         },
         {
           "os": "linux",
-            "distribution": "alpine"
-        },
-        {
-          "os": "linux",
-          "distribution": "ubuntu",
-          "versions": ["24.04"]
+          "distribution": "alpine"
         }
       ]
     },
     {
       "pre_install": [
         { "command": "yum install -y which" },
-        { "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.rpm https://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-125.0.6422.141-1.x86_64.rpm" },
-        { "command": "[ $(which google-chrome) ] || yum install -y /tmp/google-chrome.rpm" }
+        {
+          "command": "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.rpm https://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-125.0.6422.141-1.x86_64.rpm"
+        },
+        {
+          "command": "[ $(which google-chrome) ] || yum install -y /tmp/google-chrome.rpm"
+        }
       ],
       "packages": [],
-      "post_install": [
-        { "command": "rm -f /tmp/google-chrome.rpm" }
-      ],
+      "post_install": [{ "command": "rm -f /tmp/google-chrome.rpm" }],
       "constraints": [
         {
           "os": "linux",


### PR DESCRIPTION
Advantages:

- `chromium` is available on both amd64 and arm64 for most distros (chrome isn't and e.g. fails on Ubuntu)
- Less `pre_install` and `post_install` due to direct package manager call
- More lightweight and secure (as chromium doesn't bundle all the Google stuff)

No arch-agnostic solution for the old centos but that shouldn't matter much in practice.

FYI: Currently, {chromote} errors when being installed via pak on any arm64 Linux distribution as the download has amd64 hardcoded.