### PR TITLE
Add `libmecab` rule

### DIFF
--- a/rules/libmecab.json
+++ b/rules/libmecab.json
@@ -1,0 +1,39 @@
+{
+  "patterns": ["\\libmecab\\b", "\\mecab\\b"],
+  "dependencies": [
+    {
+      "packages": ["libmecab-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    },
+    {
+      "packages": ["mecab-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat"
+        },
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
For https://cran.r-project.org/web/packages/RcppMeCab/index.html

No packages for Suse and Alpine.