### PR TITLE
Update URLs for EPEL 6 & 7

### DIFF
--- a/rules/QuantLib.json
+++ b/rules/QuantLib.json
@@ -24,7 +24,7 @@
       ],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -41,7 +41,7 @@
       ],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/cmake.json
+++ b/rules/cmake.json
@@ -56,7 +56,7 @@
       "packages": ["cmake", "cmake3"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/eigen.json
+++ b/rules/eigen.json
@@ -50,7 +50,7 @@
       "packages": ["eigen3-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/exiftool.json
+++ b/rules/exiftool.json
@@ -45,7 +45,7 @@
       "packages": ["perl-Image-ExifTool"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -60,7 +60,7 @@
       "packages": ["perl-Image-ExifTool"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/gdal.json
+++ b/rules/gdal.json
@@ -45,7 +45,7 @@
       ],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -63,7 +63,7 @@
       ],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/geos.json
+++ b/rules/geos.json
@@ -33,7 +33,7 @@
       "packages": ["geos-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -48,7 +48,7 @@
       "packages": ["geos-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/ggobi.json
+++ b/rules/ggobi.json
@@ -33,7 +33,7 @@
       "packages": ["ggobi-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/glpk.json
+++ b/rules/glpk.json
@@ -79,7 +79,7 @@
       "packages": ["glpk-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/haveged.json
+++ b/rules/haveged.json
@@ -61,7 +61,7 @@
         "packages": ["haveged-devel"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
           }
         ],
         "constraints": [
@@ -76,7 +76,7 @@
         "packages": ["haveged-devel"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
           }
         ],
         "constraints": [

--- a/rules/hdf5.json
+++ b/rules/hdf5.json
@@ -61,7 +61,7 @@
       "packages": ["hdf5-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -76,7 +76,7 @@
       "packages": ["hdf5-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/hiredis.json
+++ b/rules/hiredis.json
@@ -61,7 +61,7 @@
       "packages": ["hiredis-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/leptonica.json
+++ b/rules/leptonica.json
@@ -60,7 +60,7 @@
       "packages": ["leptonica-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -75,7 +75,7 @@
       "packages": ["leptonica-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/libarchive.json
+++ b/rules/libarchive.json
@@ -82,7 +82,7 @@
       "packages": ["libarchive3-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/libavfilter.json
+++ b/rules/libavfilter.json
@@ -68,7 +68,7 @@
     {
       "packages": ["ffmpeg-devel"],
       "pre_install": [
-        { "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm" },
+        { "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm" },
         { "command": "yum install -y --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm" }
       ],
       "constraints": [

--- a/rules/libbsd.json
+++ b/rules/libbsd.json
@@ -61,7 +61,7 @@
       "packages": ["libbsd-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -76,7 +76,7 @@
       "packages": ["libbsd-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/libgit2.json
+++ b/rules/libgit2.json
@@ -58,7 +58,7 @@
       "packages": ["libgit2-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/libjq.json
+++ b/rules/libjq.json
@@ -45,7 +45,7 @@
     {
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "packages": [

--- a/rules/libsodium.json
+++ b/rules/libsodium.json
@@ -61,7 +61,7 @@
       "packages": ["libsodium-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -76,7 +76,7 @@
       "packages": ["libsodium-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/libwebp.json
+++ b/rules/libwebp.json
@@ -56,7 +56,7 @@
       "packages": ["libwebp-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/libzstd.json
+++ b/rules/libzstd.json
@@ -33,7 +33,7 @@
         "packages": ["libzstd-devel"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
           }
         ],
         "constraints": [

--- a/rules/mongodb.json
+++ b/rules/mongodb.json
@@ -30,7 +30,7 @@
       "packages": ["mongodb"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/netcdf4.json
+++ b/rules/netcdf4.json
@@ -61,7 +61,7 @@
       "packages": ["netcdf-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -76,7 +76,7 @@
       "packages": ["netcdf-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/openbabel.json
+++ b/rules/openbabel.json
@@ -50,7 +50,7 @@
       "packages": ["openbabel-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/opencl.json
+++ b/rules/opencl.json
@@ -60,7 +60,7 @@
       "packages": ["ocl-icd", "opencl-headers"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -75,7 +75,7 @@
       "packages": ["ocl-icd", "opencl-headers"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/opencv.json
+++ b/rules/opencv.json
@@ -48,7 +48,7 @@
       "packages": ["opencv-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/pandoc-citeproc.json
+++ b/rules/pandoc-citeproc.json
@@ -35,7 +35,7 @@
         "packages": ["pandoc-citeproc"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
           }
         ],
         "constraints": [

--- a/rules/pandoc.json
+++ b/rules/pandoc.json
@@ -56,7 +56,7 @@
         "packages": ["pandoc"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
           }
         ],
         "constraints": [
@@ -71,7 +71,7 @@
         "packages": ["pandoc"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
           }
         ],
         "constraints": [

--- a/rules/pari-gp.json
+++ b/rules/pari-gp.json
@@ -42,7 +42,7 @@
       "packages": ["pari-gp"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/proj.json
+++ b/rules/proj.json
@@ -61,7 +61,7 @@
       "packages": ["proj-devel", "proj-epsg"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -76,7 +76,7 @@
       "packages": ["proj-devel", "proj-epsg"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/protobuf-compiler.json
+++ b/rules/protobuf-compiler.json
@@ -79,7 +79,7 @@
       "packages": ["protobuf-compiler"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/python3.json
+++ b/rules/python3.json
@@ -48,7 +48,7 @@
         "packages": ["python34"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
           }
         ],
         "constraints": [
@@ -63,7 +63,7 @@
         "packages": ["python34"],
         "pre_install": [
           {
-            "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+            "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
           }
         ],
         "constraints": [

--- a/rules/qgis.json
+++ b/rules/qgis.json
@@ -42,7 +42,7 @@
       "packages": ["qgis-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -57,7 +57,7 @@
       "packages": ["qgis-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/rust.json
+++ b/rules/rust.json
@@ -48,7 +48,7 @@
       "packages": ["rust", "cargo"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/tesseract.json
+++ b/rules/tesseract.json
@@ -69,7 +69,7 @@
       "packages": ["tesseract-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/udunits2.json
+++ b/rules/udunits2.json
@@ -27,7 +27,7 @@
       "packages": ["udunits2-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -42,7 +42,7 @@
       "packages": ["udunits2-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/v8.json
+++ b/rules/v8.json
@@ -53,7 +53,7 @@
       "packages": ["v8-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -68,7 +68,7 @@
       "packages": ["v8-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [

--- a/rules/zeromq.json
+++ b/rules/zeromq.json
@@ -69,7 +69,7 @@
       "packages": ["zeromq-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
         }
       ],
       "constraints": [
@@ -84,7 +84,7 @@
       "packages": ["zeromq-devel"],
       "pre_install": [
         {
-          "command": "rpm -q epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+          "command": "rpm -q epel-release || yum install -y https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
         }
       ],
       "constraints": [


### PR DESCRIPTION
The old URLs are 404:
```
❯ curl --head https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
HTTP/1.1 404 Not Found

❯ curl --head https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
HTTP/1.1 404 Not Found
```

The new ones are OK:
```
❯ curl --head https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm
HTTP/1.1 200 OK

❯ curl --head https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
HTTP/1.1 200 OK
```