### PR TITLE
Fix libmecab regex

### DIFF
--- a/rules/libmecab.json
+++ b/rules/libmecab.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\libmecab\\b", "\\mecab\\b"],
+  "patterns": ["\\blibmecab\\b", "\\bmecab\\b"],
   "dependencies": [
     {
       "packages": ["libmecab-dev"],


### PR DESCRIPTION
Missing `\\b` at the beginning here