### PR TITLE
Add test for invalid regexp patterns

### DIFF
--- a/rules/libmecab.json
+++ b/rules/libmecab.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\blibmecab\\b", "\\bmecab\\b"],
+  "patterns": ["\\libmecab\\b", "\\mecab\\b"],
   "dependencies": [
     {
       "packages": ["libmecab-dev"],

--- a/rules/libmecab.json
+++ b/rules/libmecab.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\libmecab\\b", "\\mecab\\b"],
+  "patterns": ["\\blibmecab\\b", "\\bmecab\\b"],
   "dependencies": [
     {
       "packages": ["libmecab-dev"],

--- a/rules/poppler.json
+++ b/rules/poppler.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\bPoppler C\\+\\+\\\b"],
+  "patterns": ["\\bPoppler C\\+\\+\\b"],
   "dependencies": [
     {
       "packages": ["libpoppler-cpp-dev"],

--- a/test/test-patterns.js
+++ b/test/test-patterns.js
@@ -27,6 +27,10 @@ const sysreqs = JSON.parse(fs.readFileSync(SYSREQS_FILE))
 
 rules.forEach(rule => {
   rule.patterns.forEach(pattern => {
+    // Test for syntax errors, like invalid escape sequences, using Unicode-aware mode.
+    // RegExp otherwise does not perform some of these syntax checks.
+    new RegExp(pattern, 'u')
+
     const regexp = new RegExp(pattern, 'i')
     const matched = sysreqs.filter(s => s.SystemRequirements.match(regexp))
     console.log('pattern:', JSON.stringify(pattern))


### PR DESCRIPTION
Test for more invalid regexp patterns using [Unicode-aware mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode). `RegExp` in JavaScript apparently doesn't check for many invalid syntax cases, but this `u` mode does.
 
```sh
$ npm test

SyntaxError: Invalid regular expression: /\libmecab\b/u: Invalid escape
    at new RegExp (<anonymous>)
```

Fix another escape issue with poppler.