### PR TITLE
Add poppler-glib support for CentOS 8

### DIFF
--- a/rules/poppler-glib.json
+++ b/rules/poppler-glib.json
@@ -37,6 +37,20 @@
       "packages": ["poppler-glib-devel"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "packages": ["poppler-glib-devel"],
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
         { "command": "dnf config-manager --set-enabled crb" }
       ],
       "constraints": [


### PR DESCRIPTION
Same as https://github.com/rstudio/r-system-requirements/pull/179 for CentOS/Rocky 8. PPM needs this to build the Rpoppler binaries for RHEL 8.