### PR TITLE
Fix Poppler C++ regex for pdftools

### DIFF
--- a/rules/poppler.json
+++ b/rules/poppler.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\bPoppler C\\+\\+\\b"],
+  "patterns": ["\\bPoppler C\\+\\+"],
   "dependencies": [
     {
       "packages": ["libpoppler-cpp-dev"],


### PR DESCRIPTION
`\b` word boundaries don't apply if the end of the word is a character like `+`. `\B` matches non-word boundaries, but we don't really need any boundary here.
```js
> 'Poppler C++ API'.match(/\bPoppler C\+\+\b/i)
null

> 'Poppler C++ API'.match(/\bPoppler C\+\+\B/i)
[
  'Poppler C++',
  index: 0,
  input: 'Poppler C++ API',
  groups: undefined
]

> 'Poppler C++ API'.match(/\bPoppler C\+\+/i)
[
  'Poppler C++',
  index: 0,
  input: 'Poppler C++ API',
  groups: undefined
]
```