### PR TITLE
Add rule for X11 development files

### DIFF
--- a/rules/x11.json
+++ b/rules/x11.json
@@ -1,0 +1,51 @@
+{
+  "patterns": ["\\bX11\\b"],
+  "dependencies": [
+    {
+      "packages": ["libx11-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        },
+        {
+          "os": "linux",
+          "distribution": "alpine"
+        }
+      ]
+    },
+    {
+      "packages": ["libX11-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "centos"
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat"
+        },
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        },
+        {
+          "os": "linux",
+          "distribution": "sle"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The imager package (and others) needs the X11 development headers and library. The lack of this rule has led to errors in GitHub workflows starting with ubuntu-24.04, where the package does not appear to come pre-installed anymore.

Related issues:
 * https://github.com/asgr/imager/issues/24
 * https://github.com/asgr/magicaxis/pull/12

I very recently found out about this piece of infrastructure, so let me know if I'm doing something wrong.

I also found that the alpine images wouldn't build locally (`curl` couldn't resolve some hostnames, but `wget` could...). Should I treat those as local issues, or would you be happy for a separate PR moving alpine Docker images to use wget instead of curl?