### PR TITLE
Create rules for openmpt port

### DIFF
--- a/rules/openmpt.json
+++ b/rules/openmpt.json
@@ -2,7 +2,7 @@
   "patterns": ["\\bopenmpt\\b"],
   "dependencies": [
     {
-      "packages": ["libopenmpt-dev"],
+      "packages": ["libopenmpt-dev", "portaudio19-dev"],
       "constraints": [
         {
           "os": "linux",
@@ -15,7 +15,7 @@
       ]
     },
     {
-      "packages": ["libopenmpt-devel"],
+      "packages": ["libopenmpt-devel", "portaudio-devel"],
       "constraints": [
         {
           "os": "linux",
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "packages": ["libopenmpt-devel"],
+      "packages": ["libopenmpt-devel", "portaudio-devel"],
       "pre_install": [
         { "command": "yum install -y epel-release" }
       ],
@@ -48,7 +48,7 @@
       ]
     },
     {
-      "packages": ["libopenmpt-dev"],
+      "packages": ["libopenmpt-dev", "portaudio19-dev"],
       "constraints": [
         {
           "os": "linux",
@@ -56,60 +56,5 @@
         }
       ]
     }
-    {
-      "packages": ["portaudio19-dev"],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "ubuntu"
-        },
-        {
-          "os": "linux",
-          "distribution": "debian"
-        }
-      ]
-    },
-    {
-      "packages": ["portaudio-devel"],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "opensuse"
-        },
-        {
-          "os": "linux",
-          "distribution": "fedora"
-        }
-      ]
-    },
-    {
-      "packages": ["portaudio-devel"],
-      "pre_install": [
-        { "command": "yum install -y epel-release" }
-      ],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "centos"
-        },
-        {
-          "os": "linux",
-          "distribution": "rockylinux"
-        },
-        {
-          "os": "linux",
-          "distribution": "redhat"
-        }
-      ]
-    },
-    {
-      "packages": ["portaudio19-dev"],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "alpine"
-        }
-      ]
-    }  
   ]
 }


### PR DESCRIPTION
openmpt is currently a private repository containing R bindings for libopenmpt. These rules are required to set up a CHECK workflow for the R package.