### PR TITLE
Install newer libgit2 on RHEL 8 for git2r

### DIFF
--- a/rules/libgit2.json
+++ b/rules/libgit2.json
@@ -85,11 +85,12 @@
       ]
     },
     {
+      "packages": ["libgit2_1.7-devel"],
       "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled powertools" }
+        {
+          "command": "dnf install -y epel-release"
+        }
       ],
-      "packages": ["libgit2-devel"],
       "constraints": [
         {
           "os": "linux",
@@ -112,12 +113,12 @@
       ]
     },
     {
+      "packages": ["libgit2_1.7-devel"],
       "pre_install": [
         {
-          "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms"
+          "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
         }
       ],
-      "packages": ["libgit2-devel"],
       "constraints": [
         {
           "os": "linux",

--- a/rules/libgit2.json
+++ b/rules/libgit2.json
@@ -96,6 +96,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },


### PR DESCRIPTION
On Rocky/RHEL 8, the libgit2 version installed now is an old libgit2-0.26 from the PowerTools repo, too old for R packages like `git2r`. There is a newer `libgit2_1.7` package in EPEL that works though, so install that instead.
```sh
dnf install -y epel-release

dnf search libgit2
# libgit2.i686 : C implementation of the Git core methods as a library with a solid API
# libgit2.x86_64 : C implementation of the Git core methods as a library with a solid API
# libgit2_1.7-devel.x86_64 : Development files for libgit2_1.7
# libgit2-glib.i686 : Git library for GLib
# libgit2-glib.x86_64 : Git library for GLib
# libgit2_1.7.x86_64 : C implementation of the Git core methods as a library with a solid API
```