### PR TITLE
Fix netcdf4 for RHEL 8

### DIFF
--- a/rules/netcdf4.json
+++ b/rules/netcdf4.json
@@ -41,9 +41,9 @@
     {
       "packages": ["netcdf-devel"],
       "pre_install": [
-        {
-          "command": "dnf install -y epel-release"
-        }
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" },
+        { "command": "dnf install -y epel-release" }
       ],
       "constraints": [
         {
@@ -53,7 +53,8 @@
         },
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -112,9 +113,8 @@
     {
       "packages": ["netcdf-devel"],
       "pre_install": [
-        {
-          "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-        }
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms" },
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm" }
       ],
       "constraints": [
         {


### PR DESCRIPTION
Fix netcdf4 on Rocky/RHEL 8. The commands were missing a step to install PowerTools/CodeReady Builder:
```sh
dnf install -y epel-release
dnf install -y netcdf-devel

# Error: 
#  Problem: conflicting requests
#   - nothing provides libsz.so.2()(64bit) needed by netcdf-devel-4.7.0-3.el8.x86_64 from epel
```

This fixes the missing lib error:
```sh
dnf install -y dnf-plugins-core
dnf config-manager --enable powertools
```