### PR TITLE
Fix hdf5 for Rocky/RHEL 8

### DIFF
--- a/rules/hdf5.json
+++ b/rules/hdf5.json
@@ -41,9 +41,9 @@
     {
       "packages": ["hdf5-devel"],
       "pre_install": [
-        {
-          "command": "dnf install -y epel-release"
-        }
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" },
+        { "command": "dnf install -y epel-release" }
       ],
       "constraints": [
         {
@@ -53,7 +53,21 @@
         },
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "dnf install -y epel-release" }
+      ],
+      "packages": ["hdf5-devel"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },
@@ -90,9 +104,8 @@
     {
       "packages": ["hdf5-devel"],
       "pre_install": [
-        {
-          "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-        }
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms" },
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm" }
       ],
       "constraints": [
         {


### PR DESCRIPTION
Like https://github.com/rstudio/r-system-requirements/pull/202, hdf5 was missing a prerequisite PowerTools/CRB repo.
```sh
dnf install -y epel-release
dnf install -y hdf5-devel

Error: 
 Problem: conflicting requests
  - nothing provides libaec-devel(x86-64) needed by hdf5-devel-1.10.5-4.el8.x86_64 from epel
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```