### PR TITLE
Deprecate Ubuntu 20.04 (focal) and old Alpine versions for EOL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE ?= rstudio/r-system-requirements
-VARIANTS ?= focal jammy noble bookworm trixie sid centos7 centos8 rockylinux8 rockylinux9 rockylinux10 opensuse156 fedora41 alpine-3.19 alpine-3.20 alpine-3.21 alpine-3.22 alpine-3.23 alpine-edge
+VARIANTS ?= jammy noble bookworm trixie sid centos7 centos8 rockylinux8 rockylinux9 rockylinux10 opensuse156 fedora41 alpine-3.21 alpine-3.22 alpine-3.23 alpine-edge
 
 RULES ?= rules/*.json
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or see the [For Developers](#for-developers) section for how to contribute to th
 
 The rules in this catalog support the following operating systems:
 
-- Ubuntu 20.04, 22.04, 24.04, 26.04
+- Ubuntu 22.04, 24.04, 26.04
 - CentOS 7
 - Rocky Linux 8[^1], 9
 - Red Hat Enterprise Linux 7, 8, 9
@@ -54,6 +54,7 @@ The rules in this catalog support the following operating systems:
 - SUSE Linux Enterprise 15 SP6
 - Debian 12, 13, unstable
 - Fedora 41
+- Alpine 3.21, 3.22, 3.23, edge
 - Windows (for R 4.0-4.1 only)
 
 [^1]: Rocky Linux 8 is specified as `centos8` for backward compatibility.
@@ -242,7 +243,6 @@ make update-sysreqs
 packages on supported OSs.
 
 Available tags:
-- `focal` (Ubuntu 20.04)
 - `jammy` (Ubuntu 22.04)
 - `noble` (Ubuntu 24.04)
 - `bookworm` (Debian 12)
@@ -252,6 +252,10 @@ Available tags:
 - `rockylinux9` (Rocky Linux 9)
 - `opensuse156` (openSUSE 15.6)
 - `fedora41` (Fedora 41)
+- `alpine-3.21` (Alpine 3.21)
+- `alpine-3.22` (Alpine 3.22)
+- `alpine-3.23` (Alpine 3.23)
+- `alpine-edge` (Alpine edge)
 
 To build the images:
 
@@ -280,11 +284,29 @@ make test-all
 
 The JSON schema is defined in the file [`schema.json`](schema.json). Do not
 modify this file directly, since it is automatically generated. Instead, modify
-`schema.template.json` and then run `npm run generate-schema`. The
+`schema.template.json` and then run `npm run generate-schema` (not
+`node generate-schema.js` directly, which skips the formatter). The
 `generate-schema` target is automatically run when running `npm test`.
 
 If you need to modify the distros and/or versions supported in the schema definitions,
 modify [`systems.json`](systems.json).
+
+### Platform updates
+
+[`systems.json`](systems.json) is the source of truth for supported platforms.
+
+When adding a new platform, add it to:
+- [`systems.json`](systems.json) (version list)
+- [`rules/`](rules) (any rules that need platform-specific packages or install steps)
+- [`Makefile`](Makefile) (VARIANTS list)
+- [`docker/`](docker) (new Dockerfile for testing)
+- [`test/test-packages.sh`](test/test-packages.sh) (OS and version mappings)
+- [`README.md`](README.md) (supported OS list and Docker tags)
+
+When removing an end-of-life platform, remove it from the Makefile, Docker
+images, test script, and README only. Do not remove versions from
+`systems.json` or `rules/*.json`, since those are still used for resolving
+system requirements on existing installations.
 
 ## Acknowledgements
 

--- a/docker/alpine-3.19/Dockerfile
+++ b/docker/alpine-3.19/Dockerfile
@@ -1,8 +1,0 @@
-FROM alpine:3.19
-
-RUN apk update && \
-    apk add curl bash
-
-# Install jq
-RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod +x /usr/local/bin/jq

--- a/docker/alpine-3.20/Dockerfile
+++ b/docker/alpine-3.20/Dockerfile
@@ -1,8 +1,0 @@
-FROM alpine:3.20
-
-RUN apk update && \
-    apk add curl bash
-
-# Install jq
-RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod +x /usr/local/bin/jq

--- a/docker/focal/Dockerfile
+++ b/docker/focal/Dockerfile
@@ -1,8 +1,0 @@
-FROM ubuntu:focal
-
-RUN apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y curl
-
-# Install jq
-RUN curl -fsSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod +x /usr/local/bin/jq

--- a/test/test-packages.sh
+++ b/test/test-packages.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 declare -A os_identifiers=(
-    [focal]='ubuntu'
     [jammy]='ubuntu'
     [noble]='ubuntu'
     [bookworm]='debian'
@@ -23,8 +22,6 @@ declare -A os_identifiers=(
     [opensuse156]='opensuse'
     [sle156]='sle'
     [fedora41]='fedora'
-    [alpine-3.19]='alpine'
-    [alpine-3.20]='alpine'
     [alpine-3.21]='alpine'
     [alpine-3.22]='alpine'
     [alpine-3.23]='alpine'
@@ -32,7 +29,6 @@ declare -A os_identifiers=(
 )
 
 declare -A versions=(
-    [focal]='20.04'
     [jammy]='22.04'
     [noble]='24.04'
     [bookworm]='12'
@@ -50,8 +46,6 @@ declare -A versions=(
     [opensuse156]='15.6'
     [sle156]='15.6'
     [fedora41]='41'
-    [alpine-3.19]='3.19'
-    [alpine-3.20]='3.20'
     [alpine-3.21]='3.21'
     [alpine-3.22]='3.22'
     [alpine-3.23]='3.23'


### PR DESCRIPTION
Ubuntu 20.04 reached end of standard support in April 2025. A few Alpine versions are also EOL.

Also update README with better instructions for platform updates.