### PR TITLE
Fix AWS_REGION to match bucket region (us-east-1)

### DIFF
--- a/.github/workflows/publish-sysreqs.yml
+++ b/.github/workflows/publish-sysreqs.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  AWS_REGION: us-east-2
+  AWS_REGION: us-east-1
   S3_BUCKET: ${{ secrets.MANIFEST_BUCKET }}
   S3_PREFIX: sysreqs/v1
 


### PR DESCRIPTION
## Summary

The destination bucket is in us-east-1, not us-east-2 as the workflow previously assumed. Sets \`AWS_REGION: us-east-1\` in \`publish-sysreqs.yml\` to match.

\`aws s3 cp\` follows the 301 redirect silently, so the workflow might have worked anyway — but setting the correct region avoids the round-trip and keeps SDK behavior consistent.

Related: the same fix is going out in r-manifest and vulnerability-data.