### PR TITLE
Remove cross-account CloudFront invalidation step

### DIFF
--- a/.github/workflows/publish-sysreqs.yml
+++ b/.github/workflows/publish-sysreqs.yml
@@ -88,17 +88,7 @@ jobs:
           aws s3 cp /tmp/latest_checksum.txt "s3://${{ env.S3_BUCKET }}/${{ env.S3_PREFIX }}/latest_checksum.txt"
           echo "Uploaded sysreqs to s3://${{ env.S3_BUCKET }}/${{ env.S3_PREFIX }}/"
 
-      - name: Configure AWS credentials (Main account for CloudFront)
-        if: ${{ inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_MAIN_ACCOUNT_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Invalidate CloudFront cache
-        if: ${{ inputs.dry_run != true }}
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
-            --paths "/sysreqs/*"
-          echo "CloudFront invalidation created for /sysreqs/*"
+      # CloudFront invalidation intentionally omitted. Will be added back once
+      # the staged CloudFront cutover (rstudio/package-manager#17760) stands
+      # up a PPM-subaccount distribution with same-account invalidation
+      # permissions.


### PR DESCRIPTION
## Summary

Removes the CloudFront invalidation step from \`publish-sysreqs.yml\`. The step was hanging on \"Configure AWS credentials (Main account for CloudFront)\" due to OIDC trust policy / secret configuration issues with the cross-account role assumption.

Skipping invalidation until the PPM-subaccount CloudFront cutover (rstudio/package-manager#17760) lets us invalidate same-account. S3 uploads still succeed, and cached content expires via normal TTL.

Mirrored in the r-manifest and vulnerability-data repos.