### PR TITLE
Temporarily skip CloudFront invalidation wait

### DIFF
--- a/.github/workflows/publish-sysreqs.yml
+++ b/.github/workflows/publish-sysreqs.yml
@@ -108,10 +108,11 @@ jobs:
             --paths '/sysreqs/*' \
             --query 'Invalidation.Id' --output text)
           echo "Invalidation ID: ${INV_ID}"
-          aws cloudfront wait invalidation-completed \
-            --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
-            --id "${INV_ID}"
-          echo "Invalidation complete for /sysreqs/* on ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}"
+          # TODO(rstudio/aws-main#713): Re-enable wait once GetInvalidation permission lands.
+          # aws cloudfront wait invalidation-completed \
+          #   --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
+          #   --id "${INV_ID}"
+          echo "Invalidation submitted for /sysreqs/* on ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} (wait disabled, see TODO above)"
 
       - name: Verify CDN serves new sysreqs bundle
         if: ${{ inputs.dry_run != true }}


### PR DESCRIPTION
## Summary

The `ManifestInvalidation` role currently lacks `cloudfront:GetInvalidation`, which `aws cloudfront wait invalidation-completed` polls. The fix is in [rstudio/aws-main#713](https://github.com/rstudio/aws-main/pull/713) — until that lands and `pulumi up` runs, comment out the wait + completion-echo blocks so we can validate workflows end-to-end.

Each block has a `TODO(rstudio/aws-main#713)` marker so it's easy to revert.

Tracking re-enablement: [rstudio/package-manager#17823](https://github.com/rstudio/package-manager/issues/17823)

## Test plan

- [ ] Confirm the `Invalidate CloudFront` step now completes successfully (creates the invalidation, prints the ID, exits 0 without polling)
- [ ] Verify the rest of the workflow proceeds (sync-tests, etc.)