### PR TITLE
Add dotnet rule

### DIFF
--- a/rules/dotnet.json
+++ b/rules/dotnet.json
@@ -1,0 +1,34 @@
+{
+  "patterns": ["\\bdotnet\\b"],
+  "dependencies": [
+    {
+      "packages": ["dotnet-runtime-8.0"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["22.04", "24.04", "26.04"]
+        },
+        {
+          "os": "linux",
+          "distribution": "debian",
+          "versions": ["13", "unstable"]
+        },
+        {
+          "os": "linux",
+          "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["8", "9", "10"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8", "9", "10"]
+        }
+      ]
+    }
+  ]
+}

--- a/rules/dotnet10.json
+++ b/rules/dotnet10.json
@@ -1,13 +1,13 @@
 {
-  "patterns": ["\\bdotnet8\\b"],
+  "patterns": ["\\bdotnet10\\b"],
   "dependencies": [
     {
-      "packages": ["dotnet-runtime-8.0"],
+      "packages": ["dotnet-runtime-10.0"],
       "constraints": [
         {
           "os": "linux",
           "distribution": "ubuntu",
-          "versions": ["22.04", "24.04"]
+          "versions": ["24.04", "26.04"]
         },
         {
           "os": "linux",

--- a/rules/dotnet8.json
+++ b/rules/dotnet8.json
@@ -1,5 +1,5 @@
 {
-  "patterns": ["\\bdotnet\\b"],
+  "patterns": ["\\bdotnet8\\b"],
   "dependencies": [
     {
       "packages": ["dotnet-runtime-8.0"],

--- a/rules/dotnet9.json
+++ b/rules/dotnet9.json
@@ -1,14 +1,9 @@
 {
-  "patterns": ["\\bdotnet8\\b"],
+  "patterns": ["\\bdotnet9\\b"],
   "dependencies": [
     {
-      "packages": ["dotnet-runtime-8.0"],
+      "packages": ["dotnet-runtime-9.0"],
       "constraints": [
-        {
-          "os": "linux",
-          "distribution": "ubuntu",
-          "versions": ["22.04", "24.04"]
-        },
         {
           "os": "linux",
           "distribution": "redhat",


### PR DESCRIPTION
Adds `rules/dotnet8.json` for R packages that depend on the .NET 8 runtime.

Closes #238 once merged.

## Scope

Per the discussion in #238:

- Pins `dotnet-runtime-8.0` (current LTS), single rule.
- Only distros that ship the package in their default repositories — per @glin's note that "we do avoid 3rd-party repos unless absolutely essential". So Ubuntu 20.04, Debian 12, openSUSE/SLE 15.6 (which would need Microsoft's `packages-microsoft-prod` repo) are not included here. Happy to add them in a follow-up if you'd rather.
- Includes RHEL/Rocky 10 per @glin's note.

## Note on the token

Rule named `dotnet8` and pattern `\bdotnet8\b`, following the versioned-token convention already used by `python3` (and the spirit of `java8`/`java11` consumers). This way future runtimes (.NET 9, .NET 10 LTS) can be added as separate rules without breaking packages pinned to 8.

## Verification

- Package availability checked on packages.ubuntu.com (jammy/noble/resolute), packages.debian.org (trixie), packages.fedoraproject.org, and the Rocky AppStream repos for el8/el9/el10.
- `npm test` passes.