### PR TITLE
Notify #ppm-manifests on sysreqs publish

### DIFF
--- a/.github/workflows/publish-sysreqs.yml
+++ b/.github/workflows/publish-sysreqs.yml
@@ -141,3 +141,30 @@ jobs:
             exit 1
           fi
           echo "✓ CDN sync test passed -- ${MANIFEST_URL}/sysreqs/v1/ serves bundle ${GIT_SHA}"
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [publish]
+    if: always() && inputs.dry_run != true
+    steps:
+      - name: Determine notification status
+        id: notify_vars
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "text=Sysreqs publish failed (commit ${SHORT_SHA}). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "text=Sysreqs published from ${SHORT_SHA}; CDN sync verified. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          username: "GitHub Actions"
+          status: ${{ steps.notify_vars.outputs.status }}
+          text: ${{ steps.notify_vars.outputs.text }}
+          channel: "#ppm-manifests"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PPM_MANIFESTS_WEBHOOK }}


### PR DESCRIPTION
## Summary

`publish-sysreqs.yml` currently posts nothing to Slack — sysreqs publishes (push to `main` on `rules/**`/`scripts/**`) go silent unless someone tails the Actions tab. This adds a `notify` job that posts both success and failure to `#ppm-manifests`, matching the pattern other manifest workflows use.

The `SLACK_PPM_MANIFESTS_WEBHOOK` secret was added to this repo just before this PR went up.

The `notify` job is gated on `inputs.dry_run != true` so manual dry-runs stay silent. On `push:` triggers (where `inputs.dry_run` is null) the gate is treated as `true` and notifications fire.

Tracks: rstudio/package-manager#17867

## Test plan

- [ ] Push a no-op change touching `rules/`, watch Actions, confirm a success message lands in `#ppm-manifests`.
- [ ] Trigger via `workflow_dispatch` with `dry_run: true` and confirm no Slack message is posted.
- [ ] Verify the failure path (e.g., trigger on a branch where `npm test` would fail) — the `notify` job should still run because of `if: always()`.