### PR TITLE
chore: add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                         
- Add Dependabot configuration to automatically check for GitHub Actions updates weekly                                                                                                                                                                            
- Dependabot will open PRs when action versions can be updated 