### PR TITLE
workflows: drop main-account assume-role for CloudFront invalidation (DRAFT — cutover-day PR)

### DIFF
--- a/.github/workflows/publish-sysreqs.yml
+++ b/.github/workflows/publish-sysreqs.yml
@@ -93,13 +93,6 @@ jobs:
           aws s3 cp /tmp/latest_checksum.txt "s3://${{ env.S3_BUCKET }}/${{ env.S3_PREFIX }}/latest_checksum.txt"
           echo "Uploaded sysreqs to s3://${{ env.S3_BUCKET }}/${{ env.S3_PREFIX }}/"
 
-      - name: Configure AWS credentials (main account for CloudFront)
-        if: ${{ inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_MAIN_ACCOUNT_ROLE_ARN }}
-          aws-region: us-east-1
-
       - name: Invalidate CloudFront
         if: ${{ inputs.dry_run != true }}
         run: |


### PR DESCRIPTION
**DO NOT MERGE** until the rspm-sync.rstudio.com cutover has landed via rstudio/r-manifest#56 + CloudOps DNS delegation. This is part of the Phase 3 workflow sweep tracked in rstudio/package-manager#17864.

## What this PR changes

In `.github/workflows/publish-sysreqs.yml`, drops the `Configure AWS credentials (main account for CloudFront)` step before the `/sysreqs/*` invalidation. The job's earlier `Configure AWS credentials` step (using `AWS_ROLE_ARN`, the PPM subaccount role) is retained.

After the rspm-sync cutover, the `CLOUDFRONT_DISTRIBUTION_ID` repo secret will point at the same-account distribution `E1SOEI4R6M6SCP`, which can be invalidated directly with subaccount credentials.

## Coordinating the merge

On cutover day, this PR merges **synchronously** with the rspm-sync.rstudio.com DNS delegation. Specifically:

1. r-manifest#56 has applied (cert + alias + zone in place).
2. CloudOps performs NS delegation in `rstudio.com` — customer traffic flips at this instant.
3. The repo secret `CLOUDFRONT_DISTRIBUTION_ID` is flipped from `E2GGCTS3EHZS2Q` → `E1SOEI4R6M6SCP`.
4. This PR (and the sibling Phase 3 PRs in `r-manifest` and `vulnerability-data`) is merged.

Doing the secret + this PR together avoids any window where publishes invalidate the old distribution while customers are served by the new one.

Refs rstudio/package-manager#17847, rstudio/package-manager#17864

🤖 Generated with [Claude Code](https://claude.com/claude-code)