### PR TITLE
Bump GitHub Actions off Node 20 (deprecated 2026-06-16)

### DIFF
--- a/.github/workflows/publish-sysreqs.yml
+++ b/.github/workflows/publish-sysreqs.yml
@@ -153,11 +153,17 @@ jobs:
           fi
 
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          username: "GitHub Actions"
-          status: ${{ steps.notify_vars.outputs.status }}
-          text: ${{ steps.notify_vars.outputs.text }}
-          channel: "#ppm-manifests"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PPM_MANIFESTS_WEBHOOK }}
+          STATUS: ${{ steps.notify_vars.outputs.status }}
+          TEXT: ${{ steps.notify_vars.outputs.text }}
+        run: |
+          case "$STATUS" in
+            success) COLOR="#36a64f" ;;
+            failure) COLOR="#cc0000" ;;
+            *)       COLOR="#daa038" ;;
+          esac
+          payload=$(jq -n --arg color "$COLOR" --arg text "$TEXT" \
+            '{username: "GitHub Actions", attachments: [{color: $color, text: $text}]}')
+          curl -fsS -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## What

GitHub force-migrates actions still running on the Node 20 runtime to Node 24 on **2026-06-16**. This PR ensures all workflow steps in this repo run on a supported runtime ahead of that deadline.

## Context

Most of this repo's actions were already current on Node 24 and are left as-is:

- `actions/checkout@v6`
- `actions/setup-node@v6`
- `aws-actions/configure-aws-credentials@v6`
- `docker/setup-buildx-action@v4` (already Node 24)

The only Node-20 holdout was `8398a7/action-slack@v3` (in `publish-sysreqs.yml`), which has no Node-24 release.

## Change

Replace the `8398a7/action-slack@v3` "Notify Slack" step with an equivalent inline `curl` POST to the Slack incoming webhook:

- Reuses the same webhook secret (`SLACK_PPM_MANIFESTS_WEBHOOK`).
- Preserves the existing `status`/`text` outputs from the `notify_vars` step, passed via `env:`.
- Maps status to an attachment color (success/failure/other).
- Drops the `channel:` override (the webhook posts to its configured channel).

No version bumps were needed elsewhere — all other action pins were already at or above their Node-24 targets. This is a CI-only change; no application code, NEWS, or changelog is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)