### PR TITLE
Harden Slack notify + CloudFront invalidation against transient timeouts

### DIFF
--- a/.github/workflows/publish-sysreqs.yml
+++ b/.github/workflows/publish-sysreqs.yml
@@ -95,6 +95,9 @@ jobs:
 
       - name: Invalidate CloudFront
         if: ${{ inputs.dry_run != true }}
+        env:
+          AWS_MAX_ATTEMPTS: "5"
+          AWS_RETRY_MODE: adaptive
         run: |
           INV_ID=$(aws cloudfront create-invalidation \
             --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
@@ -165,5 +168,7 @@ jobs:
           esac
           payload=$(jq -n --arg color "$COLOR" --arg text "$TEXT" \
             '{username: "GitHub Actions", attachments: [{color: $color, text: $text}]}')
-          curl -fsS -X POST -H 'Content-type: application/json' \
-            --data "$payload" "$SLACK_WEBHOOK_URL"
+          curl -fsS --max-time 30 --retry 4 --retry-all-errors \
+            -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL" \
+            || echo "::warning::Slack notification failed (non-fatal)"


### PR DESCRIPTION
## Background

Two recent transient infrastructure incidents caused unnecessary CI noise and risk for the manifest-publishing pipelines:

- **2026-06-02 Slack outage**: Slack's incoming-webhook endpoint had elevated error rates and timeouts. The `Notify Slack` curl had no timeout or retry, so it could hang and, on failure, fail the `notify` job even though the publish itself succeeded.
- **2026-06-03 CloudFront connect-timeout**: CloudFront control-plane API calls (`create-invalidation`) intermittently hit connect timeouts. This was observed in sibling manifest repos and could fail the publish run despite a successful S3 upload.

This change hardens both steps in `publish-sysreqs.yml` so transient blips no longer fail the pipeline.

## Changes

- **Slack notify (`Notify Slack` step)**: add `--max-time 30 --retry 4 --retry-all-errors` to the `curl` call and make a final failure non-fatal via `|| echo "::warning::Slack notification failed (non-fatal)"`. Payload/status/color logic is unchanged.
- **CloudFront invalidation (`Invalidate CloudFront` step)**: add `AWS_MAX_ATTEMPTS: "5"` and `AWS_RETRY_MODE: adaptive` to the step `env:`, so the AWS CLI retries transient API errors with adaptive backoff. The `aws` command lines are unchanged.

CI-only change; no functional/runtime behavior of the published sysreqs bundle is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)