### PR TITLE
Apply dotnet rules to all Ubuntu versions

### DIFF
--- a/rules/dotnet10.json
+++ b/rules/dotnet10.json
@@ -6,8 +6,7 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "ubuntu",
-          "versions": ["24.04", "26.04"]
+          "distribution": "ubuntu"
         },
         {
           "os": "linux",

--- a/rules/dotnet8.json
+++ b/rules/dotnet8.json
@@ -6,8 +6,7 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "ubuntu",
-          "versions": ["22.04", "24.04"]
+          "distribution": "ubuntu"
         },
         {
           "os": "linux",

--- a/rules/dotnet9.json
+++ b/rules/dotnet9.json
@@ -6,6 +6,10 @@
       "constraints": [
         {
           "os": "linux",
+          "distribution": "ubuntu"
+        },
+        {
+          "os": "linux",
           "distribution": "redhat",
           "versions": ["8", "9", "10"]
         },


### PR DESCRIPTION
Follow-up to #241, which added the `dotnet8`, `dotnet9`, and `dotnet10` rules. Those rules pin the Ubuntu constraint to specific releases (`dotnet8` to 22.04/24.04, `dotnet10` to 24.04/26.04) and `dotnet9` has no Ubuntu constraint at all. This makes the runtime unavailable on Ubuntu releases outside the pinned set, which is a problem in practice: an R-universe build runs on Ubuntu 26.04, so a package declaring `SystemRequirements: dotnet8` does not get `dotnet-runtime-8.0` installed there, and the package fails to load during the install check.

`dotnet-runtime-8.0`, `dotnet-runtime-9.0`, and `dotnet-runtime-10.0` are all available under the same package name across every current Ubuntu release (22.04 through 26.04), so there is no reason to pin the Ubuntu version. Removing the `versions` key makes the rule apply to all supported Ubuntu releases, matching the convention already used by the majority of rules in this repository (for example `QuantLib`, `atk`, `automake`, and `blender` all specify a bare `ubuntu` distribution with no versions).

## Changes

- `rules/dotnet8.json`, `rules/dotnet10.json`: remove the `versions` array from the Ubuntu constraint so the rule applies to all supported Ubuntu releases.
- `rules/dotnet9.json`: add an unversioned Ubuntu constraint (the rule previously covered only Red Hat and Rocky Linux).

The Red Hat and Rocky Linux constraints are unchanged.

## Validation

- `npm run validate` (schema and rules) passes.
- `npm run test-patterns` passes.
- Confirmed `dotnet-runtime-{8,9,10}.0` resolve as packages on Ubuntu 22.04, 24.04, and 26.04.
