### PR TITLE
Add FAISS system requirement rule

### DIFF
--- a/rules/faiss.json
+++ b/rules/faiss.json
@@ -1,0 +1,22 @@
+{
+  "patterns": [
+    "\\bfaiss\\b",
+    "\\bfaiss c\\+\\+\\b"
+  ],
+  "dependencies": [
+    {
+      "packages": ["libfaiss-dev"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["22.04", "26.04"]
+        },
+        {
+          "os": "linux",
+          "distribution": "debian"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a system-requirements rule for FAISS C++ development headers/libraries. Motivation: the faissR BiocStaging/r-universe build requires the mandatory FAISS C++ library, but the current resolver does not map FAISS in DESCRIPTION SystemRequirements to the Debian/Ubuntu package. On Ubuntu/Debian, the development package is libfaiss-dev. This keeps CUDA/RAPIDS out of the generic CPU build requirements; GPU support remains optional and should be requested separately by GPU-capable builders.