### PR TITLE
Install dotnet-runtime-8.0 from backports PPA on Ubuntu 26.04

### DIFF
--- a/rules/dotnet8.json
+++ b/rules/dotnet8.json
@@ -20,6 +20,21 @@
           "versions": ["8", "9", "10"]
         }
       ]
+    },
+    {
+      "pre_install": [
+        { "command": "apt-get install -y software-properties-common" },
+        { "command": "add-apt-repository -y ppa:dotnet/backports" },
+        { "command": "apt-get update" }
+      ],
+      "packages": ["dotnet-runtime-8.0"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "ubuntu",
+          "versions": ["26.04"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #241, which added `dotnet8`/`dotnet9`/`dotnet10` on a "default distro repos only" basis and deliberately deferred "the Ubuntu cases that need the .NET backports PPA" to a separate PR. This is that case, and it is now needed in practice.

R-universe builds run on Ubuntu 26.04 (resolute), and a package declaring `SystemRequirements: dotnet8` currently gets no system dependency there, so it fails its install check. The reason is that Ubuntu 26.04 does not ship .NET 8 in its built-in feed at all (26.04 carries only the `10.0` line); on 26.04, `dotnet-runtime-8.0` is published exclusively via Canonical's `ppa:dotnet/backports`. So the existing `22.04`/`24.04` constraint cannot simply be extended to `26.04`: the package name resolves, but only once the PPA is added.

## Rule change

Adds a second, `26.04`-only Ubuntu dependency entry to `rules/dotnet8.json` whose `pre_install` adds `ppa:dotnet/backports` before installing `dotnet-runtime-8.0`. The existing entry (Ubuntu 22.04/24.04, RHEL/Rocky 8/9/10) is unchanged, so nothing changes for the releases that carry .NET 8 natively.

The `pre_install` step follows the idiom already established in `rules/chrome.json`, which adds a third-party PPA on Ubuntu 26.04 the same way:

```
apt-get install -y software-properties-common
add-apt-repository -y ppa:dotnet/backports
apt-get update
```

## Verification

- .NET 8 for 26.04 is published in the PPA: `ppa:dotnet/backports` provides `dotnet8` for resolute (e.g. `8.0.128-8.0.28-0ubuntu1~26.04.1~ppa1`), while the resolute main archive has no `dotnet8` source package. Microsoft's "Install .NET on Ubuntu" 26.04 table lists .NET 8 as available via the backports feed only, not the built-in feed.
- 22.04 and 24.04 carry `dotnet-runtime-8.0` in their native archives, so the existing entry remains correct and PPA-free.
- `npm test` (schema + rule validation) passes.

The Docker test images cover jammy (22.04) and noble (24.04) but not 26.04, so `make test` cannot exercise the new entry directly; the availability is verified against Launchpad and the Microsoft docs above.

Closes the deferred backports-PPA follow-up from #241.
