### PR TITLE
udunits2: add openSUSE mapping (udunits2-devel via devel:languages:R:released)

### DIFF
--- a/rules/udunits2.json
+++ b/rules/udunits2.json
@@ -129,6 +129,23 @@
       ]
     },
     {
+      "packages": ["udunits2-devel"],
+      "pre_install": [
+        {
+          "command": "zypper repos --uri 2>/dev/null | grep -q 'devel:languages:R:released' || zypper --non-interactive --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/devel:languages:R:released/15.6/devel:languages:R:released.repo"
+        },
+        {
+          "command": "zypper --non-interactive --gpg-auto-import-keys refresh"
+        }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "opensuse"
+        }
+      ]
+    },
+    {
       "packages": ["udunits-dev"],
       "pre_install": [
         {

--- a/rules/udunits2.json
+++ b/rules/udunits2.json
@@ -141,7 +141,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "opensuse"
+          "distribution": "opensuse",
+          "versions": ["15.6"]
         }
       ]
     },


### PR DESCRIPTION
## Summary

Adds an **openSUSE** entry to `rules/udunits2.json`. The rule previously had no openSUSE/SLE constraint, so any package declaring `SystemRequirements: udunits-2` — `units` and its geospatial dependents — got **no system dependency installed** on openSUSE and failed to build:

```
checking for udunits2.h... no
checking for ut_read_xml in -ludunits2... no
```

## Why the repo-add

`udunits2` isn't in the openSUSE Leap base repos — it's published in the **`devel:languages:R:released`** OBS project (the same project that provides R itself on openSUSE). So the mapping needs a `pre_install` that adds that repo before installing `udunits2-devel`, mirroring the existing **EPEL** repo-add pattern this rule already uses for RHEL/CentOS.

The repo-add is idempotent (`zypper repos --uri | grep -q … ||`), so it's a no-op on build images / systems that already have the repo (R users on openSUSE typically do), and adds it otherwise.

## Change

New entry (openSUSE):
- `pre_install`: add `devel:languages:R:released` (idempotent) + `zypper refresh`
- `packages`: `udunits2-devel`

Scoped to `opensuse` (PPM's openSUSE target is Leap 15.6); not `sle`, since the repo URL is Leap-specific.

## Validation

- `npm run validate-rules` (jsonschema) ✓
- `npm run lint` (eslint) ✓
- `npm run test-patterns-all` ✓

Surfaced by the Bioconductor/CRAN binary backfill, where `units` was a blocker on the openSUSE cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)