### PR TITLE
Document when to add third-party repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ A typical workflow for adding a new rule consists of:
    # openSUSE/SLE
    zypper search <package-name>
    ```
+
+   Only add a third-party repository via `pre_install` when a package isn't in
+   the base OS repos and the source is trusted; prefer official/base repos for
+   security and compatibility. For example, openSUSE's `udunits2` comes from the
+   `devel:languages:R:released` OBS project, accepted only because that's where
+   openSUSE's R itself is published. Make repo-adds idempotent so re-running is a
+   no-op.
 3. Add the new rule as a <code><i>rule-name</i>.json</code> file in the `rules` directory.
 4. Run the schema tests and (optionally) the system package tests locally.
 5. Submit a pull request.


### PR DESCRIPTION
Follow-up from https://github.com/rstudio/r-system-requirements/pull/261

Update README with our previously-unwritten policy of avoiding 3rd-party repos and PPAs unless absolutely necessary, and the repo is trusted enough (e.g. like an EPEL or CRAN-endorsed PPA).