### PR TITLE
RHEL 8 opencv rule is missing `opencv`

### DIFF
--- a/rules/opencv.json
+++ b/rules/opencv.json
@@ -60,7 +60,7 @@
       ]
     },
     {
-      "packages": ["opencv-devel"],
+      "packages": ["opencv-devel", "opencv"],
       "pre_install": [
         { "command": "dnf install -y dnf-plugins-core" },
         { "command": "dnf config-manager --set-enabled powertools" }
@@ -83,12 +83,26 @@
         { "command": "subscription-manager repos --enable codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms" },
         { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm" }
       ],
+      "packages": ["opencv-devel", "opencv"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "redhat",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms" },
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm" }
+      ],
       "packages": ["opencv-devel"],
       "constraints": [
         {
           "os": "linux",
           "distribution": "redhat",
-          "versions": ["8", "9"]
+          "versions": ["9"]
         }
       ]
     },


### PR DESCRIPTION
The opencv package is broken on RHEL 8 because `opencv-devel` doesn't automatically install `opencv` on RHEL/Rocky 8 only, which contains required data. You get an error when trying to use that data: `"Failed to find opencv 'share' directory".`

```sh
$ dnf install opencv-devel | grep opencv
 opencv-devel            x86_64 3.4.6-9.el8_10                 powertools 961 k
 opencv-contrib          x86_64 3.4.6-9.el8_10                 appstream  3.7 M
 opencv-core             x86_64 3.4.6-9.el8_10                 appstream  5.7 M

$ dnf install opencv-devel opencv | grep opencv
 opencv                  x86_64 3.4.6-9.el8_10                 appstream  1.6 M
 opencv-devel            x86_64 3.4.6-9.el8_10                 powertools 961 k
 opencv-contrib          x86_64 3.4.6-9.el8_10                 appstream  3.7 M
 opencv-core             x86_64 3.4.6-9.el8_10                 appstream  5.7 M
```