### PR TITLE
Use EPEL GDAL on RHEL 9/10 because stock GDAL is too minimal for GIS users

### DIFF
--- a/rules/gdal.json
+++ b/rules/gdal.json
@@ -135,10 +135,9 @@
       ]
     },
     {
-      "packages": ["gdal-devel", "gdal"],
+      "packages": ["gdal3.4-devel", "gdal3.4"],
       "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled crb" }
+        { "command": "dnf install -y epel-release" }
       ],
       "constraints": [
         {
@@ -149,9 +148,9 @@
       ]
     },
     {
-      "packages": ["gdal-devel", "gdal"],
+      "packages": ["gdal3.4-devel", "gdal3.4"],
       "pre_install": [
-        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms" }
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" }
       ],
       "constraints": [
         {
@@ -162,9 +161,9 @@
       ]
     },
     {
-      "packages": ["gdal-devel", "gdal"],
+      "packages": ["gdal3.4-devel", "gdal3.4"],
       "pre_install": [
-        { "command": "subscription-manager repos --enable codeready-builder-for-rhel-10-$(arch)-rpms" }
+        { "command": "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm" }
       ],
       "constraints": [
         {


### PR DESCRIPTION
This is going to be a breaking change, but necessary because we've had reports that RHEL's stock GDAL is too minimal to be useful for GIS users. For example, it's missing many drivers such for e.g. TIFF and GeoPackage support that even GDAL maintainers say it's unusable:
- Red Hat Bugzilla: [stock GDAL missing drivers (bz 2376350)](https://bugzilla.redhat.com/show_bug.cgi?id=2376350)
- Red Hat Jira: [RHEL-134116](https://redhat.atlassian.net/browse/RHEL-134116), [RHEL-138547](https://redhat.atlassian.net/browse/RHEL-138547)
- Red Hat Developer article: [The gdal-34 package: full-featured GIS functionality on RHEL](https://developers.redhat.com/articles/2026/02/27/gdal-34-package-full-featured-gis-functionality-rhel)
